### PR TITLE
Add config command to open config in editor

### DIFF
--- a/internal/controllers/config.go
+++ b/internal/controllers/config.go
@@ -1,0 +1,37 @@
+package controllers
+
+import (
+	"os"
+	"os/exec"
+)
+
+type configPathProvider interface {
+	ConfigFilePath() string
+}
+
+type ConfigController struct {
+	configRepo configPathProvider
+}
+
+func NewConfigController(configRepo configPathProvider) ConfigController {
+	return ConfigController{configRepo: configRepo}
+}
+
+func (c ConfigController) HandleArgs(args []string) error {
+	editor := getEditor()
+	configPath := c.configRepo.ConfigFilePath()
+
+	cmd := exec.Command(editor, configPath)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+func getEditor() string {
+	if editor, ok := os.LookupEnv("EDITOR"); ok {
+		return editor
+	}
+	return "nvim"
+}

--- a/internal/controllers/help.go
+++ b/internal/controllers/help.go
@@ -16,6 +16,7 @@ Commands
   remote    Open a project from github
   clone     Clone any git url to a project dir
   active    Open an existing session
+  config    Open the projman config in your editor
   health    Verify required dependencies are installed
   help      Show this menu
 `

--- a/internal/repositories/config.go
+++ b/internal/repositories/config.go
@@ -113,6 +113,11 @@ func (r ConfigRepository) StartingWindow() int {
 	return r.conf.SessionLayout.StartingWindow
 }
 
+func (r ConfigRepository) ConfigFilePath() string {
+	homeDir := getHomeDir()
+	return fmt.Sprintf("%v/.config/projman/config.json", homeDir)
+}
+
 // Helper function that gets the home dir without an err. If an err occurs, the program exits
 func getHomeDir() string {
 	homeDir, err := os.UserHomeDir()

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func run(args []string) {
 		"remote": controllers.NewRemoteController(github, projects, fzf, tmux, config),
 		"clone":  controllers.NewCloneController(github, fzf, tmux, config),
 		"active": controllers.NewActiveController(projects, fzf, tmux),
+		"config": controllers.NewConfigController(config),
 		"help":   controllers.NewHelpController(),
 		"health": controllers.NewHealthController(health),
 	}


### PR DESCRIPTION
## Summary
- Add `config` command that opens the projman config file in the user's editor
- Uses `$EDITOR` environment variable if set, defaults to `nvim`
- Updates help menu with new command