### PR TITLE
feat: add session provider abstraction with VS Code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Templates allow you to run a series of commands when creating new projects. Defi
 
 ## Upgrading from older versions
 
-If you're upgrading from an older version that used `session_layout`, you'll see a deprecation warning. Update your config to use the new `tmux` block:
+If you're upgrading from an older version that used `session_layout`, projman will print an error and exit. Update your config to use the new `tmux` block:
 
 **Old format (deprecated):**
 ```json

--- a/README.md
+++ b/README.md
@@ -2,23 +2,24 @@
 
 A CLI tool for managing projects on your local machine.
 projman helps you quickly create, open, and manage your
-dev projects with integrated tmux session management.
+dev projects with integrated session management.
 
 ## Features
 
 - **Project Management**: Create and open projects from local directories or GitHub repositories
-- **Tmux Integration**: Automatically manage tmux sessions for your projects
+- **Session Providers**: Choose between tmux or VS Code for opening projects
 - **Project Templates**: Use customizable templates when creating new projects
 - **Fuzzy Finder**: Built-in interactive fuzzy finding for project selection
 - **GitHub Integration**: Browse, clone, and open remote repositories
-- **Session Management**: Manage active tmux sessions
+- **Session Management**: Manage active sessions (tmux provider only)
 
 ## Installation
 
 ### Prerequisites
 
 - Go 1.24.1 or later
-- `tmux` for session management
+- `tmux` for tmux session provider (default)
+- `code` for VS Code session provider
 - `gh` for remote repository management
 - `git` for repository operations
 
@@ -54,7 +55,7 @@ Commands
   local     Open a project currently on your machine
   remote    Open a project from github
   clone     Clone any git URL into a project dir
-  active    Open an existing session
+  active    Open an existing session (tmux only)
   health    Verify required dependencies are installed
   help      Show this menu
 ```
@@ -72,7 +73,8 @@ projman uses a JSON configuration file located at `~/.config/projman/config.json
   "projectDirs": ["Projects/"],
   "openNewProjects": true,
   "templates": [],
-  "session_layout": {
+  "session_provider": "tmux",
+  "tmux": {
     "windows": ["CLI", "Code", "Server"],
     "starting_window": 2
   }
@@ -86,12 +88,50 @@ projman uses a JSON configuration file located at `~/.config/projman/config.json
 | `theme` | string | `"default"` | Selector theme preset (`default`, `bw`, `minimal`) |
 | `layout` | string | `"reverse"` | Selector input position (`reverse` = top, `default` = bottom) |
 | `projectDirs` | array | `["Projects/"]` | Directories to search for projects (relative to home directory) |
-| `openNewProjects` | boolean | `true` | Whether to automatically open new projects in tmux |
+| `openNewProjects` | boolean | `true` | Whether to automatically open new projects |
 | `templates` | array | `[]` | Project templates with commands to run |
-| `session_layout.windows` | array | `["CLI", "Code", "Server"]` | Names of tmux windows to create |
-| `session_layout.starting_window` | number | `2` | Which window to start in |
+| `session_provider` | string | `"tmux"` | Session provider to use (`tmux` or `vscode`) |
+| `tmux.windows` | array | `["CLI", "Code", "Server"]` | Names of tmux windows to create |
+| `tmux.starting_window` | number | `2` | Which window to start in |
 
-### Example Configuration
+## Session Providers
+
+projman supports multiple session providers for opening projects:
+
+### tmux (default)
+
+The tmux provider creates a new tmux session for each project with configurable windows. It supports:
+- Creating sessions with multiple named windows
+- Switching between active sessions via `projman active`
+- Attaching to sessions from outside tmux or switching from within
+
+Configure via the `tmux` block:
+
+```json
+{
+  "session_provider": "tmux",
+  "tmux": {
+    "windows": ["Terminal", "Editor", "Server", "Tests"],
+    "starting_window": 1
+  }
+}
+```
+
+### vscode
+
+The VS Code provider opens projects directly in VS Code using the `code` CLI command. 
+
+**Note**: The `projman active` command is not supported with the vscode provider.
+
+```json
+{
+  "session_provider": "vscode"
+}
+```
+
+### Example Configurations
+
+#### tmux with custom windows
 
 ```json
 {
@@ -99,6 +139,11 @@ projman uses a JSON configuration file located at `~/.config/projman/config.json
   "layout": "reverse",
   "projectDirs": ["Projects/", "Work/", "Personal/"],
   "openNewProjects": true,
+  "session_provider": "tmux",
+  "tmux": {
+    "windows": ["Terminal", "Editor", "Server", "Tests"],
+    "starting_window": 1
+  },
   "templates": [
     {
       "name": "go-project",
@@ -107,27 +152,51 @@ projman uses a JSON configuration file located at `~/.config/projman/config.json
         "touch main.go",
         "git init"
       ]
-    },
-    {
-      "name": "web-app",
-      "commands": [
-        "npm init -y",
-        "npm install express",
-        "touch server.js",
-        "git init"
-      ]
     }
-  ],
-  "session_layout": {
-    "windows": ["Terminal", "Editor", "Server", "Tests"],
-    "starting_window": 1
-  }
+  ]
+}
+```
+
+#### VS Code
+
+```json
+{
+  "theme": "minimal",
+  "layout": "reverse",
+  "projectDirs": ["Projects/"],
+  "openNewProjects": true,
+  "session_provider": "vscode"
 }
 ```
 
 ## Project Templates
 
 Templates allow you to run a series of commands when creating new projects. Define templates in your configuration file with a name and an array of commands to execute.
+
+## Upgrading from older versions
+
+If you're upgrading from an older version that used `session_layout`, you'll see a deprecation warning. Update your config to use the new `tmux` block:
+
+**Old format (deprecated):**
+```json
+{
+  "session_layout": {
+    "windows": ["CLI", "Code", "Server"],
+    "starting_window": 2
+  }
+}
+```
+
+**New format:**
+```json
+{
+  "session_provider": "tmux",
+  "tmux": {
+    "windows": ["CLI", "Code", "Server"],
+    "starting_window": 2
+  }
+}
+```
 
 ## License
 

--- a/internal/repositories/config.go
+++ b/internal/repositories/config.go
@@ -6,12 +6,21 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/danielronalds/projman/internal/services"
 )
 
 type template struct {
 	Name     string   `json:"name"`
 	Commands []string `json:"commands"`
 }
+
+type tmuxConfig struct {
+	Windows        []string `json:"windows"`
+	StartingWindow int      `json:"starting_window"`
+}
+
+type vsCodeConfig struct{}
 
 type sessionLayout struct {
 	Windows        []string `json:"windows"`
@@ -28,7 +37,10 @@ type config struct {
 	ProjectDirs     []string      `json:"projectDirs"`
 	OpenNewProjects bool          `json:"openNewProjects"`
 	Templates       []template    `json:"templates"`
-	SessionLayout   sessionLayout `json:"session_layout"`
+	SessionProvider string        `json:"session_provider"`
+	Tmux            tmuxConfig    `json:"tmux"`
+	VSCode          vsCodeConfig  `json:"vscode"`
+	SessionLayout   sessionLayout `json:"session_layout,omitempty"`
 }
 
 type ConfigRepository struct {
@@ -42,10 +54,12 @@ func NewConfigRepository() ConfigRepository {
 		ProjectDirs:     []string{"Projects/"},
 		OpenNewProjects: true,
 		Templates:       make([]template, 0),
-		SessionLayout: sessionLayout{
+		SessionProvider: "tmux",
+		Tmux: tmuxConfig{
 			Windows:        []string{"CLI", "Code", "Server"},
 			StartingWindow: 2,
 		},
+		VSCode: vsCodeConfig{},
 	}
 
 	homeDir := getHomeDir()
@@ -61,7 +75,21 @@ func NewConfigRepository() ConfigRepository {
 		os.Exit(2)
 	}
 
+	if hasLegacySessionLayout(&conf) {
+		fmt.Fprintf(os.Stderr, "Error: 'session_layout' is deprecated and no longer supported.\n")
+		fmt.Fprintf(os.Stderr, "Please move your config to the 'tmux' block. See README.md for details.\n")
+		os.Exit(1)
+	}
+
+	if conf.SessionProvider == "" {
+		conf.SessionProvider = "tmux"
+	}
+
 	return ConfigRepository{conf}
+}
+
+func hasLegacySessionLayout(conf *config) bool {
+	return len(conf.SessionLayout.Windows) > 0
 }
 
 func (r ConfigRepository) Theme() string {
@@ -105,12 +133,23 @@ func (r ConfigRepository) GetTemplateCommands(tmpl string) ([]string, error) {
 	return make([]string, 0), errors.New("no template with that name exists")
 }
 
+func (r ConfigRepository) SessionProvider() string {
+	return r.conf.SessionProvider
+}
+
+func (r ConfigRepository) TmuxConfig() services.TmuxConfig {
+	return services.TmuxConfig{
+		Windows:        r.conf.Tmux.Windows,
+		StartingWindow: r.conf.Tmux.StartingWindow,
+	}
+}
+
 func (r ConfigRepository) SessionWindows() []string {
-	return r.conf.SessionLayout.Windows
+	return r.conf.Tmux.Windows
 }
 
 func (r ConfigRepository) StartingWindow() int {
-	return r.conf.SessionLayout.StartingWindow
+	return r.conf.Tmux.StartingWindow
 }
 
 func (r ConfigRepository) ConfigFilePath() string {
@@ -118,7 +157,6 @@ func (r ConfigRepository) ConfigFilePath() string {
 	return fmt.Sprintf("%v/.config/projman/config.json", homeDir)
 }
 
-// Helper function that gets the home dir without an err. If an err occurs, the program exits
 func getHomeDir() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/repositories/config.go
+++ b/internal/repositories/config.go
@@ -89,7 +89,7 @@ func NewConfigRepository() ConfigRepository {
 }
 
 func hasLegacySessionLayout(conf *config) bool {
-	return len(conf.SessionLayout.Windows) > 0
+	return len(conf.SessionLayout.Windows) > 0 || conf.SessionLayout.StartingWindow != 0
 }
 
 func (r ConfigRepository) Theme() string {

--- a/internal/services/provider.go
+++ b/internal/services/provider.go
@@ -1,0 +1,31 @@
+package services
+
+import "fmt"
+
+type SessionProvider interface {
+	LaunchSession(name, dir string) error
+	ListActiveSessions() ([]string, error)
+	OpenActiveSession(name string) error
+	Name() string
+}
+
+type ProviderConfig interface {
+	SessionProvider() string
+	TmuxConfig() TmuxConfig
+}
+
+type TmuxConfig struct {
+	Windows        []string
+	StartingWindow int
+}
+
+func NewSessionProvider(cfg ProviderConfig) (SessionProvider, error) {
+	switch cfg.SessionProvider() {
+	case "tmux":
+		return NewTmuxProvider(cfg.TmuxConfig()), nil
+	case "vscode":
+		return NewVSCodeProvider(), nil
+	default:
+		return nil, fmt.Errorf("unknown session provider: %s", cfg.SessionProvider())
+	}
+}

--- a/internal/services/provider_test.go
+++ b/internal/services/provider_test.go
@@ -1,0 +1,89 @@
+package services
+
+import (
+	"testing"
+)
+
+type mockProviderConfig struct {
+	provider   string
+	tmuxConfig TmuxConfig
+}
+
+func (m mockProviderConfig) SessionProvider() string {
+	return m.provider
+}
+
+func (m mockProviderConfig) TmuxConfig() TmuxConfig {
+	return m.tmuxConfig
+}
+
+func TestNewSessionProvider_Tmux(t *testing.T) {
+	cfg := mockProviderConfig{
+		provider: "tmux",
+		tmuxConfig: TmuxConfig{
+			Windows:        []string{"CLI", "Code"},
+			StartingWindow: 1,
+		},
+	}
+
+	provider, err := NewSessionProvider(cfg)
+
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if provider == nil {
+		t.Fatal("expected provider to be non-nil")
+	}
+
+	if provider.Name() != "tmux" {
+		t.Errorf("expected provider name 'tmux', got '%s'", provider.Name())
+	}
+}
+
+func TestNewSessionProvider_VSCode(t *testing.T) {
+	cfg := mockProviderConfig{
+		provider: "vscode",
+	}
+
+	provider, err := NewSessionProvider(cfg)
+
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if provider == nil {
+		t.Fatal("expected provider to be non-nil")
+	}
+
+	if provider.Name() != "vscode" {
+		t.Errorf("expected provider name 'vscode', got '%s'", provider.Name())
+	}
+}
+
+func TestNewSessionProvider_UnknownProvider(t *testing.T) {
+	cfg := mockProviderConfig{
+		provider: "unknown",
+	}
+
+	provider, err := NewSessionProvider(cfg)
+
+	if err == nil {
+		t.Error("expected error for unknown provider, got nil")
+	}
+
+	if provider != nil {
+		t.Errorf("expected provider to be nil, got %v", provider)
+	}
+}
+
+func TestTmuxProvider_Name(t *testing.T) {
+	provider := NewTmuxProvider(TmuxConfig{
+		Windows:        []string{"CLI"},
+		StartingWindow: 1,
+	})
+
+	if provider.Name() != "tmux" {
+		t.Errorf("expected Name() to return 'tmux', got '%s'", provider.Name())
+	}
+}

--- a/internal/services/vscode.go
+++ b/internal/services/vscode.go
@@ -1,0 +1,35 @@
+package services
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+type VSCodeProvider struct{}
+
+func NewVSCodeProvider() VSCodeProvider {
+	return VSCodeProvider{}
+}
+
+func (p VSCodeProvider) Name() string {
+	return "vscode"
+}
+
+func (p VSCodeProvider) ListActiveSessions() ([]string, error) {
+	return nil, fmt.Errorf("vscode provider does not support session management")
+}
+
+func (p VSCodeProvider) LaunchSession(name, dir string) error {
+	cmd := exec.Command("code", dir)
+
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+
+	return cmd.Run()
+}
+
+func (p VSCodeProvider) OpenActiveSession(name string) error {
+	return fmt.Errorf("vscode provider does not support session management")
+}

--- a/internal/services/vscode_test.go
+++ b/internal/services/vscode_test.go
@@ -1,0 +1,37 @@
+package services
+
+import (
+	"testing"
+)
+
+func TestVSCodeProvider_Name(t *testing.T) {
+	provider := NewVSCodeProvider()
+
+	if provider.Name() != "vscode" {
+		t.Errorf("expected Name() to return 'vscode', got '%s'", provider.Name())
+	}
+}
+
+func TestVSCodeProvider_ListActiveSessions_ReturnsError(t *testing.T) {
+	provider := NewVSCodeProvider()
+
+	sessions, err := provider.ListActiveSessions()
+
+	if err == nil {
+		t.Error("expected ListActiveSessions() to return error, got nil")
+	}
+
+	if sessions != nil {
+		t.Errorf("expected sessions to be nil, got %v", sessions)
+	}
+}
+
+func TestVSCodeProvider_OpenActiveSession_ReturnsError(t *testing.T) {
+	provider := NewVSCodeProvider()
+
+	err := provider.OpenActiveSession("test-session")
+
+	if err == nil {
+		t.Error("expected OpenActiveSession() to return error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `SessionProvider` interface allowing users to choose between tmux and VS Code for opening projects
- Tmux remains the default provider
- Move `session_layout` config to `tmux` block (breaking change - errors if old config detected)
- Health check now verifies the correct provider executable (`tmux` or `code`)

## Breaking Changes

The `session_layout` config key is no longer supported. Users must migrate to the new `tmux` block:

```json
// Old (no longer supported)
{
  "session_layout": {
    "windows": ["CLI", "Code", "Server"],
    "starting_window": 2
  }
}

// New
{
  "session_provider": "tmux",
  "tmux": {
    "windows": ["CLI", "Code", "Server"],
    "starting_window": 2
  }
}
```

## New Configuration

```json
{
  "session_provider": "tmux",  // or "vscode"
  "tmux": {
    "windows": ["CLI", "Code", "Server"],
    "starting_window": 2
  }
}
```

## Testing

- `go build ./...`
- `go test ./...`