### PR TITLE
Add spinner for remote project fetching

### DIFF
--- a/internal/controllers/remote.go
+++ b/internal/controllers/remote.go
@@ -3,6 +3,8 @@ package controllers
 import (
 	"errors"
 	"fmt"
+
+	"github.com/danielronalds/projman/internal/ui"
 )
 
 type projectPath = string
@@ -37,8 +39,7 @@ func NewRemoteController(remote remoteProjectManager, local localProjectsIndex, 
 }
 
 func (c RemoteController) HandleArgs(args []string) error {
-	fmt.Println("fetching projects...")
-	remoteProjects, err := c.remote.ListProjects()
+	remoteProjects, err := ui.WithSpinner("fetching projects...", c.remote.ListProjects)
 	if err != nil {
 		return fmt.Errorf("unable to fetch github projects: %v", err.Error())
 	}

--- a/internal/ui/spinner.go
+++ b/internal/ui/spinner.go
@@ -1,0 +1,34 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+var spinnerFrames = []string{"⣾ ", "⣽ ", "⣻ ", "⢿ ", "⡿ ", "⣟ ", "⣯ ", "⣷ "}
+
+func WithSpinner[T any](message string, fn func() (T, error)) (T, error) {
+	done := make(chan struct{})
+
+	go func() {
+		i := 0
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				fmt.Printf("\r%s%s", spinnerFrames[i%len(spinnerFrames)], message)
+				time.Sleep(100 * time.Millisecond)
+				i++
+			}
+		}
+	}()
+
+	result, err := fn()
+
+	close(done)
+	fmt.Printf("\r%s\r", strings.Repeat(" ", len(message)+len(spinnerFrames[0])))
+
+	return result, err
+}

--- a/internal/ui/spinner.go
+++ b/internal/ui/spinner.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -10,8 +11,11 @@ var spinnerFrames = []string{"⣾ ", "⣽ ", "⣻ ", "⢿ ", "⡿ ", "⣟ ", "�
 
 func WithSpinner[T any](message string, fn func() (T, error)) (T, error) {
 	done := make(chan struct{})
+	var wg sync.WaitGroup
 
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		i := 0
 		for {
 			select {
@@ -28,6 +32,7 @@ func WithSpinner[T any](message string, fn func() (T, error)) (T, error) {
 	result, err := fn()
 
 	close(done)
+	wg.Wait()
 	fmt.Printf("\r%s\r", strings.Repeat(" ", len(message)+len(spinnerFrames[0])))
 
 	return result, err


### PR DESCRIPTION
## What

Replaces the static `fetching projects...` message in the `remote` command with an animated Braille spinner.

## How

- Added `internal/ui/spinner.go` with a generic `WithSpinner[T any]` helper that runs a goroutine-based spinner alongside any blocking `func() (T, error)` call
- Updated `RemoteController.HandleArgs` to use `ui.WithSpinner` when calling `ListProjects`

## Testing

Run `projman remote` and confirm the spinner animates while GitHub repos are being fetched, then clears cleanly before the fzf selector opens.