### PR TITLE
feat: add --provider flag

### DIFF
--- a/internal/services/provider.go
+++ b/internal/services/provider.go
@@ -19,6 +19,19 @@ type TmuxConfig struct {
 	StartingWindow int
 }
 
+type ProviderConfigOverride struct {
+	ProviderConfig
+	provider string
+}
+
+func NewProviderConfigOverride(base ProviderConfig, provider string) ProviderConfig {
+	return ProviderConfigOverride{base, provider}
+}
+
+func (p ProviderConfigOverride) SessionProvider() string {
+	return p.provider
+}
+
 func NewSessionProvider(cfg ProviderConfig) (SessionProvider, error) {
 	switch cfg.SessionProvider() {
 	case "tmux":

--- a/internal/services/provider_test.go
+++ b/internal/services/provider_test.go
@@ -77,6 +77,48 @@ func TestNewSessionProvider_UnknownProvider(t *testing.T) {
 	}
 }
 
+func TestProviderConfigOverride_SessionProvider(t *testing.T) {
+	base := mockProviderConfig{
+		provider: "tmux",
+	}
+
+	override := NewProviderConfigOverride(base, "vscode")
+
+	if override.SessionProvider() != "vscode" {
+		t.Errorf("expected SessionProvider() to return 'vscode', got '%s'", override.SessionProvider())
+	}
+}
+
+func TestProviderConfigOverride_TmuxConfig(t *testing.T) {
+	expectedConfig := TmuxConfig{
+		Windows:        []string{"CLI", "Code"},
+		StartingWindow: 1,
+	}
+
+	base := mockProviderConfig{
+		provider:   "tmux",
+		tmuxConfig: expectedConfig,
+	}
+
+	override := NewProviderConfigOverride(base, "vscode")
+
+	result := override.TmuxConfig()
+
+	if len(result.Windows) != len(expectedConfig.Windows) {
+		t.Fatalf("expected %d windows, got %d", len(expectedConfig.Windows), len(result.Windows))
+	}
+
+	for i, window := range result.Windows {
+		if window != expectedConfig.Windows[i] {
+			t.Errorf("expected window %d to be '%s', got '%s'", i, expectedConfig.Windows[i], window)
+		}
+	}
+
+	if result.StartingWindow != expectedConfig.StartingWindow {
+		t.Errorf("expected StartingWindow to be %d, got %d", expectedConfig.StartingWindow, result.StartingWindow)
+	}
+}
+
 func TestTmuxProvider_Name(t *testing.T) {
 	provider := NewTmuxProvider(TmuxConfig{
 		Windows:        []string{"CLI"},

--- a/main.go
+++ b/main.go
@@ -14,26 +14,36 @@ type controller interface {
 	HandleArgs(args []string) error
 }
 
-func parseProviderFlag(args []string) (string, []string) {
+func parseProviderFlag(args []string) (string, []string, error) {
 	remaining := make([]string, 0, len(args))
 	provider := ""
 	for i := 0; i < len(args); i++ {
-		if args[i] == "--provider" && i+1 < len(args) {
+		if args[i] == "--provider" {
+			if i+1 >= len(args) {
+				return "", nil, fmt.Errorf("--provider requires a value")
+			}
 			provider = args[i+1]
 			i++
 		} else if value, ok := strings.CutPrefix(args[i], "--provider="); ok {
+			if value == "" {
+				return "", nil, fmt.Errorf("--provider requires a value")
+			}
 			provider = value
 		} else {
 			remaining = append(remaining, args[i])
 		}
 	}
-	return provider, remaining
+	return provider, remaining, nil
 }
 
 func run(args []string) {
 	config := repositories.NewConfigRepository()
 
-	providerFlag, args := parseProviderFlag(args)
+	providerFlag, args, err := parseProviderFlag(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err.Error())
+		os.Exit(1)
+	}
 
 	var providerCfg services.ProviderConfig = config
 	if providerFlag != "" {


### PR DESCRIPTION
## What

Adds a `--provider` flag that overrides the `session_provider` config value at runtime.

```sh
projman --provider vscode myproject
projman local --provider tmux
```

## Why

Allows switching providers without editing `~/.config/projman/config.json`, useful when working across environments or testing a different provider temporarily.

## Changes

- `internal/services/provider.go` - adds `ProviderConfigOverride` and `NewProviderConfigOverride`, an alternate `ProviderConfig` implementation that wraps the real config and overrides the provider name
- `main.go` - adds `parseProviderFlag` to strip `--provider` from args before routing, wires the override into `NewSessionProvider` when the flag is set

Unknown provider values produce the existing error: `unknown session provider: <value>`