### PR TITLE
Add CI pipeline with clint

### DIFF
--- a/.github/pipelines/ci.yaml
+++ b/.github/pipelines/ci.yaml
@@ -1,0 +1,17 @@
+description: "CI pipeline for projman"
+steps:
+  - name: "Formatting"
+    cmd: "mise run lint:fmt"
+    on_fail: "gofmt -d ."
+
+  - name: "Vet"
+    cmd: "mise run lint:vet"
+
+  - name: "Static Analysis"
+    cmd: "mise run lint:static"
+
+  - name: "Tests"
+    cmd: "mise run test"
+
+  - name: "Dependency Check"
+    cmd: "mise run lint:deps"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,4 +22,5 @@ jobs:
       - name: Run CI Pipeline
         uses: danielronalds/clint-runner@main
         with:
+          go-version: '1.26'
           pipeline: ci

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,27 +1,25 @@
-name: Go
+name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
   pull_request:
-    branches: [ "main" ]
+    types: [opened, synchronize, reopened]
 
 jobs:
-  build:
+  ci:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.24.1'
+      - name: Install Mise
+        uses: jdx/mise-action@v3
+        with:
+          install: true
 
-    - name: Build
-      run: go build -v ./...
-
-    - name: Test
-      run: go test -v github.com/danielronalds/...
-
-    - name: Format Check
-      uses: Jerome1337/gofmt-action@v1.0.5
+      - name: Run CI Pipeline
+        uses: danielronalds/clint-runner@main
+        with:
+          pipeline: ci

--- a/clint.yaml
+++ b/clint.yaml
@@ -1,0 +1,1 @@
+pipelines_dir: ".github/pipelines/"

--- a/internal/services/projects.go
+++ b/internal/services/projects.go
@@ -18,11 +18,6 @@ type ProjectsService struct {
 	localProjects map[projectName]projectPath
 }
 
-type project struct {
-	name string
-	path string
-}
-
 func NewProjectsService(config projectsConfig) ProjectsService {
 	return ProjectsService{
 		config:        config,
@@ -63,8 +58,9 @@ func (s ProjectsService) ListProjects() ([]string, error) {
 
 func (s ProjectsService) GetPath(project string) (string, error) {
 	if len(s.localProjects) == 0 {
-		// Fetching the projects if they haven't already been fetched
-		s.ListProjects()
+		if _, err := s.ListProjects(); err != nil {
+			return "", err
+		}
 	}
 
 	path, ok := s.localProjects[project]
@@ -77,8 +73,9 @@ func (s ProjectsService) GetPath(project string) (string, error) {
 
 func (s ProjectsService) IsLocalProject(project string) bool {
 	if len(s.localProjects) == 0 {
-		// Fetching the projects if they haven't already been fetched
-		s.ListProjects()
+		if _, err := s.ListProjects(); err != nil {
+			return false
+		}
 	}
 
 	_, ok := s.localProjects[project]

--- a/mise.toml
+++ b/mise.toml
@@ -31,3 +31,15 @@ run = "golangci-lint run"
 [tasks."lint:deps"]
 description = "Check for unused or missing dependencies"
 run = "go mod tidy && git diff --exit-code go.mod go.sum"
+
+[tasks.test]
+description = "Runs all tests in the project"
+run = "bash scripts/test.sh"
+
+[tasks.release]
+description = "Creates a GitHub release for the latest tag"
+run = "bash scripts/release.sh"
+
+[tasks.clean]
+description = "Cleans unwanted files"
+run = "bash scripts/clean.sh"

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+main() {
+    local files=("projman")
+
+    for file in "${files[@]}"; do
+        if [[ ! -e $file ]]; then
+            continue
+        fi
+
+        rm "$file"
+        echo "Removed './$file'"
+    done
+}
+
+main

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+main() {
+    if [[ -x "$(command -v "gotestsum")" ]]; then
+        gotestsum ./...
+    else
+        go test ./...
+    fi
+}
+
+main


### PR DESCRIPTION
## Summary

- Add `test`, `release`, and `clean` mise tasks backed by scripts in `scripts/`
- Add clint CI pipeline (`.github/pipelines/ci.yaml`) covering formatting, vet, static analysis, tests, and dependency checks
- Replace ad-hoc GitHub Actions workflow with `clint-runner`
- Fix lint issues in `internal/services/projects.go` (unused type, unchecked errors)

## Test plan

- [ ] `mise tasks` lists all new tasks
- [ ] `clint ci` passes locally
- [ ] GitHub Actions workflow runs successfully