### PR TITLE
feat: add worktree management foundation with new subcommand

### DIFF
--- a/docs/worktree-implementation-plan.md
+++ b/docs/worktree-implementation-plan.md
@@ -1,0 +1,251 @@
+# Worktree Support Implementation Plan
+
+projman currently has no worktree management. Users who work with git worktrees need to manually run git commands and manage sessions separately. This adds a `wt` (alias `worktree`) subcommand group that integrates worktree lifecycle management with projman's session launching.
+
+## Design
+
+### Worktree location
+
+Worktrees are created as sibling directories: `<parent>/<project>-<name>/`.
+
+Example for project at `~/Projects/projman/`:
+
+```
+~/Projects/projman/                   # main project
+~/Projects/projman-feature-auth/      # worktree
+~/Projects/projman-bugfix-123/        # worktree
+```
+
+Discovery uses `git worktree list --porcelain` (works from any worktree in the repo). The user-facing worktree name strips the project prefix, so `projman-feature-auth` is shown as `feature-auth`.
+
+### Command structure
+
+```
+projman wt              -> fuzzy select existing worktree, open session
+projman wt <name>       -> open session in named worktree directly
+projman wt new <name>   -> create worktree + branch, open session
+projman wt checkout     -> fetch remotes, fuzzy select branch, create worktree, open session
+projman wt rm           -> fuzzy select worktree, remove it + prune
+```
+
+Session names use `<project>-<worktree>` format. All commands error if not inside a git repository.
+
+### Controller architecture
+
+```
+controllers/
+  worktree.go              # package controllers -- sub-dispatcher + unexported subcommand interface
+  worktree/                # package worktree -- individual sub-controllers
+    open.go                # Default select + direct open
+    new.go                 # Create new worktree
+    rm.go                  # Remove worktree
+    checkout.go            # Fetch + checkout remote branch
+```
+
+The `subcommand` interface is defined (unexported) in `controllers/worktree.go`:
+
+```go
+type subcommand interface {
+    Handle(projectRoot, projectName string, args []string) error
+}
+```
+
+Sub-controllers satisfy this implicitly via Go's structural typing.
+
+---
+
+## Stage 1: Foundation + `new` command
+
+- [x] Complete
+
+Sets up the service, dispatcher, and the first subcommand.
+
+### Files to create
+
+**`internal/services/worktree.go`** -- Stateless service. Methods needed for this stage:
+
+| Method | Implementation | Purpose |
+|--------|---------------|---------|
+| `IsGitRepo(dir)` | `git rev-parse --git-dir` | Check if dir is inside a git repo |
+| `MainWorktreePath(dir)` | `git worktree list --porcelain`, parse first entry | Get main worktree path |
+| `CreateWorktree(dir, name)` | Resolve context, then `git worktree add ../<project>-<name> -b <name>` | Create sibling worktree with new branch |
+
+Internal `resolveContext(dir)` helper parses `git worktree list --porcelain` to get main worktree path and project name.
+
+**`internal/services/worktree_test.go`** -- Integration tests (guarded by `testing.Short()`) for the above methods.
+
+**`internal/controllers/worktree/new.go`** -- Sub-controller with narrow interfaces:
+
+```go
+type worktreeCreator interface {
+    CreateWorktree(dir, name string) (string, error)
+}
+type sessionLauncher interface {
+    LaunchSession(name, dir string) error
+}
+```
+
+Handle: require name in `args[0]` -> `CreateWorktree` -> `LaunchSession` with `<project>-<name>`.
+
+**`internal/controllers/worktree/new_test.go`** -- Mock-based tests: missing name, successful create.
+
+**`internal/controllers/worktree.go`** -- Main dispatcher. Defines `subcommand` interface, `gitRepoChecker` and `mainWorktreePathFinder` interfaces. `HandleArgs` resolves context, dispatches to `new` subcommand. Unknown subcommands error for now (open/direct-open added in Stage 2).
+
+### Files to modify
+
+**`main.go`** -- Create `WorktreeService`, wire `WorktreeController` with `"worktree"` and `"wt"` keys.
+
+**`internal/controllers/help.go`** -- Add `wt` entry, bump version.
+
+### Verification
+
+1. `gofmt -l .` + `go vet ./...` + `go test ./...`
+2. `projman wt new test-feature` from inside a git repo -- creates sibling worktree, opens session
+3. `projman wt new` with no name -- errors with usage hint
+4. `projman wt` outside a git repo -- errors
+
+---
+
+## Stage 2: Listing and opening worktrees
+
+- [ ] Complete
+
+Adds default fuzzy select and direct-open by name.
+
+### Files to create
+
+**`internal/controllers/worktree/open.go`** -- Sub-controller with narrow interfaces:
+
+```go
+type worktreeLister interface {
+    ListWorktrees(dir string) ([]string, error)
+}
+type worktreePathFinder interface {
+    WorktreePath(dir, name string) (string, error)
+}
+type selecter interface {
+    Select(options []string) (string, error)
+}
+type sessionLauncher interface {
+    LaunchSession(name, dir string) error
+}
+```
+
+Handle: if no args, list -> select -> open. If args, treat as direct name -> resolve path -> open. Error with guidance if no worktrees exist.
+
+**`internal/controllers/worktree/open_test.go`** -- Mock-based tests: no worktrees, successful select, direct open, not found.
+
+### Files to modify
+
+**`internal/services/worktree.go`** -- Add methods:
+
+| Method | Implementation | Purpose |
+|--------|---------------|---------|
+| `ListWorktrees(dir)` | `git worktree list --porcelain`, exclude main, strip `<project>-` prefix | User-facing worktree names |
+| `WorktreePath(dir, name)` | Match name against parsed worktree list | Resolve name to full path |
+
+**`internal/services/worktree_test.go`** -- Add tests for the new methods.
+
+**`internal/controllers/worktree.go`** -- Wire `open` sub-controller. Set it as default handler + fallback for unknown subcommands (direct name open).
+
+### Verification
+
+1. `go test ./...`
+2. `projman wt` -- shows existing worktrees in fuzzy finder, opens session on select
+3. `projman wt feature-auth` -- opens session directly in named worktree
+4. `projman wt` with no worktrees -- error with "create one with projman wt new" guidance
+
+---
+
+## Stage 3: `checkout` command
+
+- [ ] Complete
+
+Adds fetching remote branches and checking them out into worktrees.
+
+### Files to create
+
+**`internal/controllers/worktree/checkout.go`** -- Sub-controller:
+
+```go
+type remoteBranchLister interface {
+    ListRemoteBranches(dir string) ([]string, error)
+}
+type worktreeCheckout interface {
+    CheckoutWorktree(dir, remoteBranch string) (string, error)
+}
+type selecter interface {
+    Select(options []string) (string, error)
+}
+type sessionLauncher interface {
+    LaunchSession(name, dir string) error
+}
+```
+
+Handle: `WithSpinner` around `ListRemoteBranches` -> select -> `CheckoutWorktree` -> `LaunchSession`. Strip `origin/` for session name.
+
+**`internal/controllers/worktree/checkout_test.go`** -- Mock-based tests: no remote branches, successful checkout.
+
+### Files to modify
+
+**`internal/services/worktree.go`** -- Add methods:
+
+| Method | Implementation | Purpose |
+|--------|---------------|---------|
+| `ListRemoteBranches(dir)` | `git fetch --all --prune` + `git branch -r --format=%(refname:short)` | Fetch and list remote branches |
+| `CheckoutWorktree(dir, branch)` | Strip `origin/` prefix, `git worktree add ../<project>-<local> <branch>` | Create worktree from remote branch |
+
+**`internal/services/worktree_test.go`** -- Add integration tests.
+
+**`internal/controllers/worktree.go`** -- Wire `checkout` into subcommands map.
+
+### Verification
+
+1. `go test ./...`
+2. `projman wt checkout` -- fetches branches with spinner, shows fuzzy finder, creates worktree and opens session
+
+---
+
+## Stage 4: `rm` command
+
+- [ ] Complete
+
+Adds worktree removal with fuzzy selection.
+
+### Files to create
+
+**`internal/controllers/worktree/rm.go`** -- Sub-controller:
+
+```go
+type worktreeLister interface {
+    ListWorktrees(dir string) ([]string, error)
+}
+type worktreeRemover interface {
+    RemoveWorktree(dir, name string) error
+}
+type selecter interface {
+    Select(options []string) (string, error)
+}
+```
+
+Handle: list -> select -> remove + prune + print confirmation. Git naturally errors if inside the target worktree.
+
+**`internal/controllers/worktree/rm_test.go`** -- Mock-based tests: no worktrees, successful remove.
+
+### Files to modify
+
+**`internal/services/worktree.go`** -- Add method:
+
+| Method | Implementation | Purpose |
+|--------|---------------|---------|
+| `RemoveWorktree(dir, name)` | Resolve path, `git worktree remove <path>` + `git worktree prune` | Remove and clean up |
+
+**`internal/services/worktree_test.go`** -- Add integration test.
+
+**`internal/controllers/worktree.go`** -- Wire `rm` into subcommands map.
+
+### Verification
+
+1. `go test ./...`
+2. `projman wt rm` -- shows worktrees, select one, removes it and prints confirmation
+3. Try removing the worktree you're currently in -- should get a clear error from git

--- a/internal/controllers/help.go
+++ b/internal/controllers/help.go
@@ -18,11 +18,12 @@ Commands
   active    Open an existing session
   config    Open the projman config in your editor
   rm        Remove a project from your machine
+  worktree  Manage git worktrees (alias: wt)
   health    Verify required dependencies are installed
   help      Show this menu
 `
 
-const VERSION = "0.7.0"
+const VERSION = "0.8.0"
 
 type HelpController struct{}
 

--- a/internal/controllers/worktree.go
+++ b/internal/controllers/worktree.go
@@ -59,7 +59,7 @@ func (c WorktreeController) HandleArgs(args []string) error {
 	subArgs := args[1:]
 
 	if len(subArgs) == 0 {
-		return errors.New("usage: projman wt <new> [args]")
+		return errors.New("usage: projman wt <subcommand> [args]")
 	}
 
 	subcmd, ok := c.subcommands[subArgs[0]]

--- a/internal/controllers/worktree.go
+++ b/internal/controllers/worktree.go
@@ -1,0 +1,71 @@
+package controllers
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/danielronalds/projman/internal/controllers/worktree"
+)
+
+type subcommand interface {
+	Handle(projectRoot, projectName string, args []string) error
+}
+
+type gitRepoChecker interface {
+	IsGitRepo(dir string) bool
+}
+
+type mainWorktreePathFinder interface {
+	MainWorktreePath(dir string) (string, error)
+}
+
+type worktreeCreator interface {
+	CreateWorktree(dir, name string) (string, error)
+}
+
+type WorktreeController struct {
+	git         gitRepoChecker
+	worktrees   mainWorktreePathFinder
+	subcommands map[string]subcommand
+}
+
+func NewWorktreeController(git gitRepoChecker, worktrees mainWorktreePathFinder, worktreeCreator worktreeCreator, sessions sessionLauncher) WorktreeController {
+	subcommands := map[string]subcommand{
+		"new": worktree.NewNewController(worktreeCreator, sessions),
+	}
+
+	return WorktreeController{git, worktrees, subcommands}
+}
+
+func (c WorktreeController) HandleArgs(args []string) error {
+	dir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting working directory: %v", err.Error())
+	}
+
+	if !c.git.IsGitRepo(dir) {
+		return errors.New("not inside a git repository")
+	}
+
+	mainPath, err := c.worktrees.MainWorktreePath(dir)
+	if err != nil {
+		return fmt.Errorf("resolving worktree context: %v", err.Error())
+	}
+
+	projectName := filepath.Base(mainPath)
+
+	subArgs := args[1:]
+
+	if len(subArgs) == 0 {
+		return errors.New("usage: projman wt <new> [args]")
+	}
+
+	subcmd, ok := c.subcommands[subArgs[0]]
+	if !ok {
+		return fmt.Errorf("unknown worktree command %q", subArgs[0])
+	}
+
+	return subcmd.Handle(mainPath, projectName, subArgs[1:])
+}

--- a/internal/controllers/worktree/new.go
+++ b/internal/controllers/worktree/new.go
@@ -1,0 +1,39 @@
+package worktree
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+)
+
+type worktreeCreator interface {
+	CreateWorktree(dir, name string) (string, error)
+}
+
+type sessionLauncher interface {
+	LaunchSession(name, dir string) error
+}
+
+type NewController struct {
+	worktrees worktreeCreator
+	sessions  sessionLauncher
+}
+
+func NewNewController(worktrees worktreeCreator, sessions sessionLauncher) NewController {
+	return NewController{worktrees, sessions}
+}
+
+func (c NewController) Handle(projectRoot, projectName string, args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: projman wt new <name>")
+	}
+
+	branchName := args[0]
+
+	path, err := c.worktrees.CreateWorktree(projectRoot, branchName)
+	if err != nil {
+		return fmt.Errorf("creating worktree: %v", err.Error())
+	}
+
+	return c.sessions.LaunchSession(filepath.Base(path), path)
+}

--- a/internal/controllers/worktree/new_test.go
+++ b/internal/controllers/worktree/new_test.go
@@ -1,0 +1,69 @@
+package worktree
+
+import (
+	"strings"
+	"testing"
+)
+
+type mockWorktreeCreator struct {
+	returnPath string
+	returnErr  error
+	calledDir  string
+	calledName string
+}
+
+func (m *mockWorktreeCreator) CreateWorktree(dir, name string) (string, error) {
+	m.calledDir = dir
+	m.calledName = name
+	return m.returnPath, m.returnErr
+}
+
+type mockSessionLauncher struct {
+	returnErr  error
+	calledName string
+	calledDir  string
+}
+
+func (m *mockSessionLauncher) LaunchSession(name, dir string) error {
+	m.calledName = name
+	m.calledDir = dir
+	return m.returnErr
+}
+
+func TestNewControllerHandle(t *testing.T) {
+	t.Run("missingName", func(t *testing.T) {
+		controller := NewNewController(&mockWorktreeCreator{}, &mockSessionLauncher{})
+
+		err := controller.Handle("/projects/myapp", "myapp", []string{})
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "usage") {
+			t.Fatalf("expected usage error, got: %v", err)
+		}
+	})
+
+	t.Run("successfulCreate", func(t *testing.T) {
+		worktrees := &mockWorktreeCreator{returnPath: "/projects/myapp-feature-auth"}
+		sessions := &mockSessionLauncher{}
+		controller := NewNewController(worktrees, sessions)
+
+		err := controller.Handle("/projects/myapp", "myapp", []string{"feature/auth"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if worktrees.calledDir != "/projects/myapp" {
+			t.Fatalf("CreateWorktree dir = %q, want %q", worktrees.calledDir, "/projects/myapp")
+		}
+		if worktrees.calledName != "feature/auth" {
+			t.Fatalf("CreateWorktree name = %q, want %q", worktrees.calledName, "feature/auth")
+		}
+		if sessions.calledName != "myapp-feature-auth" {
+			t.Fatalf("LaunchSession name = %q, want %q", sessions.calledName, "myapp-feature-auth")
+		}
+		if sessions.calledDir != "/projects/myapp-feature-auth" {
+			t.Fatalf("LaunchSession dir = %q, want %q", sessions.calledDir, "/projects/myapp-feature-auth")
+		}
+	})
+}

--- a/internal/services/worktree.go
+++ b/internal/services/worktree.go
@@ -1,0 +1,85 @@
+package services
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type WorktreeService struct{}
+
+func NewWorktreeService() WorktreeService {
+	return WorktreeService{}
+}
+
+func (s WorktreeService) IsGitRepo(dir string) bool {
+	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd.Dir = dir
+	return cmd.Run() == nil
+}
+
+func (s WorktreeService) MainWorktreePath(dir string) (string, error) {
+	mainPath, _, err := resolveContext(dir)
+	if err != nil {
+		return "", err
+	}
+	return mainPath, nil
+}
+
+func (s WorktreeService) CreateWorktree(dir, name string) (string, error) {
+	mainPath, projectName, err := resolveContext(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolving git context: %v", err.Error())
+	}
+
+	sanitised := sanitiseForDirectory(name)
+	dirName := projectName + "-" + sanitised
+	worktreePath := filepath.Join(filepath.Dir(mainPath), dirName)
+
+	cmd := exec.Command("git", "worktree", "add", worktreePath, "-b", name)
+	cmd.Dir = mainPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("creating worktree: %v", strings.TrimSpace(string(output)))
+	}
+
+	return worktreePath, nil
+}
+
+func resolveContext(dir string) (mainPath, projectName string, err error) {
+	cmd := exec.Command("git", "worktree", "list", "--porcelain")
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		return "", "", fmt.Errorf("listing worktrees: %v", err.Error())
+	}
+
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		if path, ok := strings.CutPrefix(line, "worktree "); ok {
+			mainPath = path
+			break
+		}
+	}
+
+	if mainPath == "" {
+		return "", "", fmt.Errorf("could not determine main worktree path")
+	}
+
+	projectName = filepath.Base(mainPath)
+	return mainPath, projectName, nil
+}
+
+var nonAlphanumericDashDotUnderscore = regexp.MustCompile(`[^a-zA-Z0-9\-._]`)
+var multipleDashes = regexp.MustCompile(`-{2,}`)
+
+func sanitiseForDirectory(name string) string {
+	result := strings.ReplaceAll(name, "/", "-")
+	result = strings.ReplaceAll(result, " ", "-")
+	result = nonAlphanumericDashDotUnderscore.ReplaceAllString(result, "")
+	result = multipleDashes.ReplaceAllString(result, "-")
+	result = strings.Trim(result, "-")
+	return result
+}

--- a/internal/services/worktree.go
+++ b/internal/services/worktree.go
@@ -35,6 +35,9 @@ func (s WorktreeService) CreateWorktree(dir, name string) (string, error) {
 	}
 
 	sanitised := sanitiseForDirectory(name)
+	if sanitised == "" {
+		return "", fmt.Errorf("invalid worktree name %q: results in empty directory name after sanitisation", name)
+	}
 	dirName := projectName + "-" + sanitised
 	worktreePath := filepath.Join(filepath.Dir(mainPath), dirName)
 

--- a/internal/services/worktree_test.go
+++ b/internal/services/worktree_test.go
@@ -95,6 +95,8 @@ func TestCreateWorktree(t *testing.T) {
 	}
 
 	run(repoDir, "git", "init")
+	run(repoDir, "git", "config", "user.email", "test@test.com")
+	run(repoDir, "git", "config", "user.name", "Test")
 	run(repoDir, "git", "commit", "--allow-empty", "-m", "initial")
 
 	s := NewWorktreeService()

--- a/internal/services/worktree_test.go
+++ b/internal/services/worktree_test.go
@@ -142,4 +142,11 @@ func TestCreateWorktree(t *testing.T) {
 			t.Fatalf("expected branch 'feature/my-feature' to exist, got: %q", string(output))
 		}
 	})
+
+	t.Run("invalidNameAllSpecialChars", func(t *testing.T) {
+		_, err := s.CreateWorktree(repoDir, "@#$%")
+		if err == nil {
+			t.Fatalf("expected error for invalid name, got nil")
+		}
+	})
 }

--- a/internal/services/worktree_test.go
+++ b/internal/services/worktree_test.go
@@ -80,7 +80,9 @@ func TestCreateWorktree(t *testing.T) {
 
 	tmpDir, _ := filepath.EvalSymlinks(t.TempDir())
 	repoDir := filepath.Join(tmpDir, "myproject")
-	os.MkdirAll(repoDir, 0755)
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatalf("failed to create repo dir: %v", err)
+	}
 
 	run := func(dir string, args ...string) {
 		t.Helper()

--- a/internal/services/worktree_test.go
+++ b/internal/services/worktree_test.go
@@ -1,0 +1,141 @@
+package services
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSanitiseForDirectory(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "slashToDash", input: "feature/foo", want: "feature-foo"},
+		{name: "spaceToDash", input: "feature/foo bar", want: "feature-foo-bar"},
+		{name: "underscorePreserved", input: "my_branch", want: "my_branch"},
+		{name: "collapsedDashes", input: "feat//double", want: "feat-double"},
+		{name: "trimLeadingTrailing", input: "--leading--", want: "leading"},
+		{name: "dotPreserved", input: "v1.2.3", want: "v1.2.3"},
+		{name: "specialCharsStripped", input: "feat@#$%name", want: "featname"},
+		{name: "simple", input: "test-feature", want: "test-feature"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitiseForDirectory(tt.input)
+			if got != tt.want {
+				t.Fatalf("sanitiseForDirectory(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsGitRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	s := NewWorktreeService()
+
+	t.Run("insideGitRepo", func(t *testing.T) {
+		cwd, _ := os.Getwd()
+		if !s.IsGitRepo(cwd) {
+			t.Fatalf("expected current directory to be a git repo")
+		}
+	})
+
+	t.Run("outsideGitRepo", func(t *testing.T) {
+		if s.IsGitRepo(os.TempDir()) {
+			t.Fatalf("expected temp dir to not be a git repo")
+		}
+	})
+}
+
+func TestMainWorktreePath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	s := NewWorktreeService()
+
+	cwd, _ := os.Getwd()
+	got, err := s.MainWorktreePath(cwd)
+	if err != nil {
+		t.Fatalf("MainWorktreePath() error = %v", err)
+	}
+
+	if !strings.HasSuffix(got, "projman") {
+		t.Fatalf("MainWorktreePath() = %q, want suffix 'projman'", got)
+	}
+}
+
+func TestCreateWorktree(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tmpDir, _ := filepath.EvalSymlinks(t.TempDir())
+	repoDir := filepath.Join(tmpDir, "myproject")
+	os.MkdirAll(repoDir, 0755)
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, output)
+		}
+	}
+
+	run(repoDir, "git", "init")
+	run(repoDir, "git", "commit", "--allow-empty", "-m", "initial")
+
+	s := NewWorktreeService()
+
+	t.Run("simpleWorktree", func(t *testing.T) {
+		path, err := s.CreateWorktree(repoDir, "test-branch")
+		if err != nil {
+			t.Fatalf("CreateWorktree() error = %v", err)
+		}
+
+		expectedPath := filepath.Join(tmpDir, "myproject-test-branch")
+		if path != expectedPath {
+			t.Fatalf("CreateWorktree() path = %q, want %q", path, expectedPath)
+		}
+
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Fatalf("worktree directory does not exist at %q", path)
+		}
+	})
+
+	t.Run("branchWithSlash", func(t *testing.T) {
+		path, err := s.CreateWorktree(repoDir, "feature/my-feature")
+		if err != nil {
+			t.Fatalf("CreateWorktree() error = %v", err)
+		}
+
+		expectedPath := filepath.Join(tmpDir, "myproject-feature-my-feature")
+		if path != expectedPath {
+			t.Fatalf("CreateWorktree() path = %q, want %q", path, expectedPath)
+		}
+
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Fatalf("worktree directory does not exist at %q", path)
+		}
+
+		branchCmd := exec.Command("git", "branch", "--list", "feature/my-feature")
+		branchCmd.Dir = repoDir
+		output, err := branchCmd.Output()
+		if err != nil {
+			t.Fatalf("git branch --list error = %v", err)
+		}
+		if !strings.Contains(string(output), "feature/my-feature") {
+			t.Fatalf("expected branch 'feature/my-feature' to exist, got: %q", string(output))
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ func run(args []string) {
 	creater := services.NewCreaterService(config)
 	health := services.NewHealthService()
 	git := services.NewGitService()
+	worktree := services.NewWorktreeService()
 
 	sessionProvider, err := services.NewSessionProvider(providerCfg)
 	if err != nil {
@@ -69,15 +70,17 @@ func run(args []string) {
 	}
 
 	controllerMap := map[string]controller{
-		"new":    controllers.NewNewController(selector, creater, sessionProvider, config),
-		"local":  controllers.NewOpenController(projects, selector, sessionProvider),
-		"remote": controllers.NewRemoteController(github, projects, selector, sessionProvider, config),
-		"clone":  controllers.NewCloneController(github, selector, sessionProvider, config),
-		"active": controllers.NewActiveController(projects, selector, sessionProvider),
-		"config": controllers.NewConfigController(config),
-		"rm":     controllers.NewRmController(projects, selector, git),
-		"help":   controllers.NewHelpController(),
-		"health": controllers.NewHealthController(health, config),
+		"new":      controllers.NewNewController(selector, creater, sessionProvider, config),
+		"local":    controllers.NewOpenController(projects, selector, sessionProvider),
+		"remote":   controllers.NewRemoteController(github, projects, selector, sessionProvider, config),
+		"clone":    controllers.NewCloneController(github, selector, sessionProvider, config),
+		"active":   controllers.NewActiveController(projects, selector, sessionProvider),
+		"config":   controllers.NewConfigController(config),
+		"rm":       controllers.NewRmController(projects, selector, git),
+		"help":     controllers.NewHelpController(),
+		"health":   controllers.NewHealthController(health, config),
+		"worktree": controllers.NewWorktreeController(worktree, worktree, worktree, sessionProvider),
+		"wt":       controllers.NewWorktreeController(worktree, worktree, worktree, sessionProvider),
 	}
 
 	handler, ok := controllerMap[cmd]


### PR DESCRIPTION
## Summary
- Adds `WorktreeService` with git worktree lifecycle methods (`IsGitRepo`, `MainWorktreePath`, `CreateWorktree`) and directory name sanitisation
- Adds `WorktreeController` dispatcher with subcommand architecture for future extensibility
- Implements `wt new <name>` subcommand to create a sibling worktree and open a session
- Wires `worktree` and `wt` commands into the CLI, updates help menu, bumps version to 0.8.0

## Test plan
- [x] `go test ./...` passes (unit + integration tests for sanitisation, git operations, and controller logic)
- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `projman wt new feature/test` creates sibling worktree with correct directory name and branch
- [x] `projman wt new` with no name shows usage error
- [x] `projman wt` outside a git repo shows error