### PR TITLE
feat: add worktree listing and opening with fuzzy select

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ Direct Go commands also work:
 - Test single test: `go test ./internal/services -run TestFunctionName`
 - Format fix: `gofmt -w .`
 
+**Important** Before commiting any work in this project, run `clint` to check the CI
+
 ## Architecture
 
 Three-layer architecture: **Controllers** (CLI handlers) -> **Services** (business logic) -> **Repositories** (config/data).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Direct Go commands also work:
 - Test single test: `go test ./internal/services -run TestFunctionName`
 - Format fix: `gofmt -w .`
 
-**Important** Before commiting any work in this project, run `clint` to check the CI
+**Important** Before committing any work in this project, run `clint` to check the CI
 
 ## Architecture
 

--- a/docs/worktree-implementation-plan.md
+++ b/docs/worktree-implementation-plan.md
@@ -1,5 +1,7 @@
 # Worktree Support Implementation Plan
 
+- [ ] TODO: Add copying of files in .gitignore over to new worktrees
+
 projman currently has no worktree management. Users who work with git worktrees need to manually run git commands and manage sessions separately. This adds a `wt` (alias `worktree`) subcommand group that integrates worktree lifecycle management with projman's session launching.
 
 ## Design

--- a/docs/worktree-implementation-plan.md
+++ b/docs/worktree-implementation-plan.md
@@ -110,7 +110,7 @@ Handle: require name in `args[0]` -> `CreateWorktree` -> `LaunchSession` with `<
 
 ## Stage 2: Listing and opening worktrees
 
-- [ ] Complete
+- [x] Complete
 
 Adds default fuzzy select and direct-open by name.
 

--- a/internal/controllers/worktree.go
+++ b/internal/controllers/worktree.go
@@ -13,30 +13,29 @@ type subcommand interface {
 	Handle(projectRoot, projectName string, args []string) error
 }
 
-type gitRepoChecker interface {
+type worktreeManager interface {
 	IsGitRepo(dir string) bool
-}
-
-type mainWorktreePathFinder interface {
 	MainWorktreePath(dir string) (string, error)
-}
-
-type worktreeCreator interface {
 	CreateWorktree(dir, name string) (string, error)
+	ListWorktrees(dir string) ([]string, error)
+	WorktreePath(dir, name string) (string, error)
 }
 
 type WorktreeController struct {
-	git         gitRepoChecker
-	worktrees   mainWorktreePathFinder
-	subcommands map[string]subcommand
+	worktrees      worktreeManager
+	subcommands    map[string]subcommand
+	defaultHandler subcommand
 }
 
-func NewWorktreeController(git gitRepoChecker, worktrees mainWorktreePathFinder, worktreeCreator worktreeCreator, sessions sessionLauncher) WorktreeController {
+func NewWorktreeController(worktrees worktreeManager, fzf selecter, sessions sessionLauncher) WorktreeController {
+	openController := worktree.NewOpenController(worktrees, worktrees, fzf, sessions)
+
 	subcommands := map[string]subcommand{
-		"new": worktree.NewNewController(worktreeCreator, sessions),
+		"new":  worktree.NewNewController(worktrees, sessions),
+		"open": openController,
 	}
 
-	return WorktreeController{git, worktrees, subcommands}
+	return WorktreeController{worktrees, subcommands, openController}
 }
 
 func (c WorktreeController) HandleArgs(args []string) error {
@@ -45,7 +44,7 @@ func (c WorktreeController) HandleArgs(args []string) error {
 		return fmt.Errorf("getting working directory: %v", err.Error())
 	}
 
-	if !c.git.IsGitRepo(dir) {
+	if !c.worktrees.IsGitRepo(dir) {
 		return errors.New("not inside a git repository")
 	}
 
@@ -55,17 +54,15 @@ func (c WorktreeController) HandleArgs(args []string) error {
 	}
 
 	projectName := filepath.Base(mainPath)
-
 	subArgs := args[1:]
 
 	if len(subArgs) == 0 {
-		return errors.New("usage: projman wt <subcommand> [args]")
+		return c.defaultHandler.Handle(mainPath, projectName, nil)
 	}
 
-	subcmd, ok := c.subcommands[subArgs[0]]
-	if !ok {
-		return fmt.Errorf("unknown worktree command %q", subArgs[0])
+	if subcmd, ok := c.subcommands[subArgs[0]]; ok {
+		return subcmd.Handle(mainPath, projectName, subArgs[1:])
 	}
 
-	return subcmd.Handle(mainPath, projectName, subArgs[1:])
+	return c.defaultHandler.Handle(mainPath, projectName, subArgs)
 }

--- a/internal/controllers/worktree/open.go
+++ b/internal/controllers/worktree/open.go
@@ -1,0 +1,81 @@
+package worktree
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type worktreeLister interface {
+	ListWorktrees(dir string) ([]string, error)
+}
+
+type worktreePathFinder interface {
+	WorktreePath(dir, name string) (string, error)
+}
+
+type selecter interface {
+	Select(options []string) (string, error)
+}
+
+const baseSuffix = " (base)"
+
+type OpenController struct {
+	worktrees worktreeLister
+	paths     worktreePathFinder
+	fzf       selecter
+	sessions  sessionLauncher
+}
+
+func NewOpenController(worktrees worktreeLister, paths worktreePathFinder, fzf selecter, sessions sessionLauncher) OpenController {
+	return OpenController{worktrees, paths, fzf, sessions}
+}
+
+func (c OpenController) Handle(projectRoot, projectName string, args []string) error {
+	name, err := c.resolveWorktreeName(projectRoot, projectName, args)
+	if err != nil {
+		return err
+	}
+
+	path, err := c.paths.WorktreePath(projectRoot, name)
+	if err != nil {
+		return fmt.Errorf("resolving worktree path: %v", err.Error())
+	}
+
+	sessionName := projectName + "-" + name
+	if name == projectName {
+		sessionName = projectName
+	}
+	return c.sessions.LaunchSession(sessionName, path)
+}
+
+func (c OpenController) resolveWorktreeName(projectRoot, projectName string, args []string) (string, error) {
+	if len(args) > 0 {
+		return args[0], nil
+	}
+
+	worktrees, err := c.worktrees.ListWorktrees(projectRoot)
+	if err != nil {
+		return "", fmt.Errorf("listing worktrees: %v", err.Error())
+	}
+
+	if len(worktrees) == 0 {
+		return "", errors.New("no worktrees found, create one with: projman wt new <name>")
+	}
+
+	displayNames := make([]string, len(worktrees))
+	for i, name := range worktrees {
+		if name == projectName {
+			displayNames[i] = name + baseSuffix
+		} else {
+			displayNames[i] = name
+		}
+	}
+
+	selected, err := c.fzf.Select(displayNames)
+	if err != nil {
+		return "", errors.New("no worktree selected")
+	}
+
+	return strings.TrimSuffix(selected, baseSuffix), nil
+}

--- a/internal/controllers/worktree/open_test.go
+++ b/internal/controllers/worktree/open_test.go
@@ -1,0 +1,193 @@
+package worktree
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type mockWorktreeLister struct {
+	returnNames []string
+	returnErr   error
+	calledDir   string
+}
+
+func (m *mockWorktreeLister) ListWorktrees(dir string) ([]string, error) {
+	m.calledDir = dir
+	return m.returnNames, m.returnErr
+}
+
+type mockWorktreePathFinder struct {
+	returnPath string
+	returnErr  error
+	calledDir  string
+	calledName string
+}
+
+func (m *mockWorktreePathFinder) WorktreePath(dir, name string) (string, error) {
+	m.calledDir = dir
+	m.calledName = name
+	return m.returnPath, m.returnErr
+}
+
+type mockSelecter struct {
+	returnSelected string
+	returnErr      error
+	calledOptions  []string
+}
+
+func (m *mockSelecter) Select(options []string) (string, error) {
+	m.calledOptions = options
+	return m.returnSelected, m.returnErr
+}
+
+func TestOpenControllerHandle(t *testing.T) {
+	t.Run("noWorktreesExist", func(t *testing.T) {
+		lister := &mockWorktreeLister{returnNames: nil}
+		paths := &mockWorktreePathFinder{}
+		fzf := &mockSelecter{}
+		sessions := &mockSessionLauncher{}
+
+		controller := NewOpenController(lister, paths, fzf, sessions)
+		err := controller.Handle("/projects/myapp", "myapp", nil)
+
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "no worktrees found") {
+			t.Fatalf("expected 'no worktrees found' error, got: %v", err)
+		}
+	})
+
+	t.Run("fuzzySelectSuccess", func(t *testing.T) {
+		lister := &mockWorktreeLister{returnNames: []string{"myapp", "feature-auth", "bugfix-login"}}
+		paths := &mockWorktreePathFinder{returnPath: "/projects/myapp-feature-auth"}
+		fzf := &mockSelecter{returnSelected: "feature-auth"}
+		sessions := &mockSessionLauncher{}
+
+		controller := NewOpenController(lister, paths, fzf, sessions)
+		err := controller.Handle("/projects/myapp", "myapp", nil)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(fzf.calledOptions) != 3 {
+			t.Fatalf("Select called with %d options, want 3", len(fzf.calledOptions))
+		}
+		if fzf.calledOptions[0] != "myapp (base)" {
+			t.Fatalf("Select options[0] = %q, want %q", fzf.calledOptions[0], "myapp (base)")
+		}
+		if paths.calledName != "feature-auth" {
+			t.Fatalf("WorktreePath name = %q, want %q", paths.calledName, "feature-auth")
+		}
+		if sessions.calledName != "myapp-feature-auth" {
+			t.Fatalf("LaunchSession name = %q, want %q", sessions.calledName, "myapp-feature-auth")
+		}
+		if sessions.calledDir != "/projects/myapp-feature-auth" {
+			t.Fatalf("LaunchSession dir = %q, want %q", sessions.calledDir, "/projects/myapp-feature-auth")
+		}
+	})
+
+	t.Run("fuzzySelectMain", func(t *testing.T) {
+		lister := &mockWorktreeLister{returnNames: []string{"myapp", "feature-auth"}}
+		paths := &mockWorktreePathFinder{returnPath: "/projects/myapp"}
+		fzf := &mockSelecter{returnSelected: "myapp (base)"}
+		sessions := &mockSessionLauncher{}
+
+		controller := NewOpenController(lister, paths, fzf, sessions)
+		err := controller.Handle("/projects/myapp", "myapp", nil)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if paths.calledName != "myapp" {
+			t.Fatalf("WorktreePath name = %q, want %q", paths.calledName, "myapp")
+		}
+		if sessions.calledName != "myapp" {
+			t.Fatalf("LaunchSession name = %q, want %q", sessions.calledName, "myapp")
+		}
+		if sessions.calledDir != "/projects/myapp" {
+			t.Fatalf("LaunchSession dir = %q, want %q", sessions.calledDir, "/projects/myapp")
+		}
+	})
+
+	t.Run("fuzzySelectCancelled", func(t *testing.T) {
+		lister := &mockWorktreeLister{returnNames: []string{"feature-auth"}}
+		paths := &mockWorktreePathFinder{}
+		fzf := &mockSelecter{returnErr: errors.New("no selection made")}
+		sessions := &mockSessionLauncher{}
+
+		controller := NewOpenController(lister, paths, fzf, sessions)
+		err := controller.Handle("/projects/myapp", "myapp", nil)
+
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "no worktree selected") {
+			t.Fatalf("expected 'no worktree selected' error, got: %v", err)
+		}
+	})
+
+	t.Run("directOpenByName", func(t *testing.T) {
+		lister := &mockWorktreeLister{}
+		paths := &mockWorktreePathFinder{returnPath: "/projects/myapp-feature-auth"}
+		fzf := &mockSelecter{}
+		sessions := &mockSessionLauncher{}
+
+		controller := NewOpenController(lister, paths, fzf, sessions)
+		err := controller.Handle("/projects/myapp", "myapp", []string{"feature-auth"})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if lister.calledDir != "" {
+			t.Fatalf("ListWorktrees should not be called for direct open")
+		}
+		if paths.calledDir != "/projects/myapp" {
+			t.Fatalf("WorktreePath dir = %q, want %q", paths.calledDir, "/projects/myapp")
+		}
+		if paths.calledName != "feature-auth" {
+			t.Fatalf("WorktreePath name = %q, want %q", paths.calledName, "feature-auth")
+		}
+		if sessions.calledName != "myapp-feature-auth" {
+			t.Fatalf("LaunchSession name = %q, want %q", sessions.calledName, "myapp-feature-auth")
+		}
+	})
+
+	t.Run("directOpenMain", func(t *testing.T) {
+		lister := &mockWorktreeLister{}
+		paths := &mockWorktreePathFinder{returnPath: "/projects/myapp"}
+		fzf := &mockSelecter{}
+		sessions := &mockSessionLauncher{}
+
+		controller := NewOpenController(lister, paths, fzf, sessions)
+		err := controller.Handle("/projects/myapp", "myapp", []string{"myapp"})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sessions.calledName != "myapp" {
+			t.Fatalf("LaunchSession name = %q, want %q", sessions.calledName, "myapp")
+		}
+		if sessions.calledDir != "/projects/myapp" {
+			t.Fatalf("LaunchSession dir = %q, want %q", sessions.calledDir, "/projects/myapp")
+		}
+	})
+
+	t.Run("directOpenNotFound", func(t *testing.T) {
+		lister := &mockWorktreeLister{}
+		paths := &mockWorktreePathFinder{returnErr: errors.New("worktree \"nope\" not found")}
+		fzf := &mockSelecter{}
+		sessions := &mockSessionLauncher{}
+
+		controller := NewOpenController(lister, paths, fzf, sessions)
+		err := controller.Handle("/projects/myapp", "myapp", []string{"nope"})
+
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "resolving worktree path") {
+			t.Fatalf("expected 'resolving worktree path' error, got: %v", err)
+		}
+	})
+}

--- a/internal/services/worktree.go
+++ b/internal/services/worktree.go
@@ -51,26 +51,86 @@ func (s WorktreeService) CreateWorktree(dir, name string) (string, error) {
 	return worktreePath, nil
 }
 
-func resolveContext(dir string) (mainPath, projectName string, err error) {
+func (s WorktreeService) ListWorktrees(dir string) ([]string, error) {
+	mainPath, projectName, err := resolveContext(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolving git context: %v", err.Error())
+	}
+
+	paths, err := listWorktreeEntries(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	prefix := projectName + "-"
+	for _, path := range paths {
+		if path == mainPath {
+			names = append(names, projectName)
+			continue
+		}
+		name := strings.TrimPrefix(filepath.Base(path), prefix)
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+func (s WorktreeService) WorktreePath(dir, name string) (string, error) {
+	mainPath, projectName, err := resolveContext(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolving git context: %v", err.Error())
+	}
+
+	paths, err := listWorktreeEntries(dir)
+	if err != nil {
+		return "", err
+	}
+
+	if name == projectName {
+		return mainPath, nil
+	}
+
+	prefix := projectName + "-"
+	for _, path := range paths {
+		if path == mainPath {
+			continue
+		}
+		if strings.TrimPrefix(filepath.Base(path), prefix) == name {
+			return path, nil
+		}
+	}
+
+	return "", fmt.Errorf("worktree %q not found", name)
+}
+
+func listWorktreeEntries(dir string) ([]string, error) {
 	cmd := exec.Command("git", "worktree", "list", "--porcelain")
 	cmd.Dir = dir
 	output, err := cmd.Output()
 	if err != nil {
-		return "", "", fmt.Errorf("listing worktrees: %v", err.Error())
+		return nil, fmt.Errorf("listing worktrees: %v", err.Error())
 	}
 
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines {
+	var paths []string
+	for _, line := range strings.Split(string(output), "\n") {
 		if path, ok := strings.CutPrefix(line, "worktree "); ok {
-			mainPath = path
-			break
+			paths = append(paths, path)
 		}
 	}
+	return paths, nil
+}
 
-	if mainPath == "" {
+func resolveContext(dir string) (mainPath, projectName string, err error) {
+	paths, err := listWorktreeEntries(dir)
+	if err != nil {
+		return "", "", err
+	}
+
+	if len(paths) == 0 {
 		return "", "", fmt.Errorf("could not determine main worktree path")
 	}
 
+	mainPath = paths[0]
 	projectName = filepath.Base(mainPath)
 	return mainPath, projectName, nil
 }

--- a/internal/services/worktree.go
+++ b/internal/services/worktree.go
@@ -21,7 +21,7 @@ func (s WorktreeService) IsGitRepo(dir string) bool {
 }
 
 func (s WorktreeService) MainWorktreePath(dir string) (string, error) {
-	mainPath, _, err := resolveContext(dir)
+	mainPath, _, _, err := resolveContext(dir)
 	if err != nil {
 		return "", err
 	}
@@ -29,7 +29,7 @@ func (s WorktreeService) MainWorktreePath(dir string) (string, error) {
 }
 
 func (s WorktreeService) CreateWorktree(dir, name string) (string, error) {
-	mainPath, projectName, err := resolveContext(dir)
+	mainPath, projectName, _, err := resolveContext(dir)
 	if err != nil {
 		return "", fmt.Errorf("resolving git context: %v", err.Error())
 	}
@@ -52,14 +52,9 @@ func (s WorktreeService) CreateWorktree(dir, name string) (string, error) {
 }
 
 func (s WorktreeService) ListWorktrees(dir string) ([]string, error) {
-	mainPath, projectName, err := resolveContext(dir)
+	mainPath, projectName, paths, err := resolveContext(dir)
 	if err != nil {
 		return nil, fmt.Errorf("resolving git context: %v", err.Error())
-	}
-
-	paths, err := listWorktreeEntries(dir)
-	if err != nil {
-		return nil, err
 	}
 
 	var names []string
@@ -76,14 +71,9 @@ func (s WorktreeService) ListWorktrees(dir string) ([]string, error) {
 }
 
 func (s WorktreeService) WorktreePath(dir, name string) (string, error) {
-	mainPath, projectName, err := resolveContext(dir)
+	mainPath, projectName, paths, err := resolveContext(dir)
 	if err != nil {
 		return "", fmt.Errorf("resolving git context: %v", err.Error())
-	}
-
-	paths, err := listWorktreeEntries(dir)
-	if err != nil {
-		return "", err
 	}
 
 	if name == projectName {
@@ -120,19 +110,19 @@ func listWorktreeEntries(dir string) ([]string, error) {
 	return paths, nil
 }
 
-func resolveContext(dir string) (mainPath, projectName string, err error) {
-	paths, err := listWorktreeEntries(dir)
+func resolveContext(dir string) (mainPath, projectName string, paths []string, err error) {
+	paths, err = listWorktreeEntries(dir)
 	if err != nil {
-		return "", "", err
+		return "", "", nil, err
 	}
 
 	if len(paths) == 0 {
-		return "", "", fmt.Errorf("could not determine main worktree path")
+		return "", "", nil, fmt.Errorf("could not determine main worktree path")
 	}
 
 	mainPath = paths[0]
 	projectName = filepath.Base(mainPath)
-	return mainPath, projectName, nil
+	return mainPath, projectName, paths, nil
 }
 
 var nonAlphanumericDashDotUnderscore = regexp.MustCompile(`[^a-zA-Z0-9\-._]`)

--- a/internal/services/worktree_test.go
+++ b/internal/services/worktree_test.go
@@ -150,3 +150,142 @@ func TestCreateWorktree(t *testing.T) {
 		}
 	})
 }
+
+func TestListWorktrees(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tmpDir, _ := filepath.EvalSymlinks(t.TempDir())
+	repoDir := filepath.Join(tmpDir, "myproject")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatalf("failed to create repo dir: %v", err)
+	}
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, output)
+		}
+	}
+
+	run(repoDir, "git", "init")
+	run(repoDir, "git", "config", "user.email", "test@test.com")
+	run(repoDir, "git", "config", "user.name", "Test")
+	run(repoDir, "git", "commit", "--allow-empty", "-m", "initial")
+
+	s := NewWorktreeService()
+
+	t.Run("onlyBase", func(t *testing.T) {
+		names, err := s.ListWorktrees(repoDir)
+		if err != nil {
+			t.Fatalf("ListWorktrees() error = %v", err)
+		}
+		if len(names) != 1 {
+			t.Fatalf("ListWorktrees() returned %d names, want 1", len(names))
+		}
+		if names[0] != "myproject" {
+			t.Fatalf("ListWorktrees()[0] = %q, want %q", names[0], "myproject")
+		}
+	})
+
+	if _, err := s.CreateWorktree(repoDir, "feature-one"); err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+	if _, err := s.CreateWorktree(repoDir, "feature/two"); err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+
+	t.Run("withWorktrees", func(t *testing.T) {
+		names, err := s.ListWorktrees(repoDir)
+		if err != nil {
+			t.Fatalf("ListWorktrees() error = %v", err)
+		}
+		if len(names) != 3 {
+			t.Fatalf("ListWorktrees() returned %d names, want 3", len(names))
+		}
+		expected := map[string]bool{"myproject": true, "feature-one": true, "feature-two": true}
+		for _, name := range names {
+			if !expected[name] {
+				t.Fatalf("unexpected worktree name %q", name)
+			}
+		}
+	})
+
+	t.Run("fromWorktreeDir", func(t *testing.T) {
+		worktreeDir := filepath.Join(tmpDir, "myproject-feature-one")
+		names, err := s.ListWorktrees(worktreeDir)
+		if err != nil {
+			t.Fatalf("ListWorktrees() from worktree dir error = %v", err)
+		}
+		if len(names) != 3 {
+			t.Fatalf("ListWorktrees() from worktree dir returned %d names, want 3", len(names))
+		}
+	})
+}
+
+func TestWorktreePath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tmpDir, _ := filepath.EvalSymlinks(t.TempDir())
+	repoDir := filepath.Join(tmpDir, "myproject")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatalf("failed to create repo dir: %v", err)
+	}
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, output)
+		}
+	}
+
+	run(repoDir, "git", "init")
+	run(repoDir, "git", "config", "user.email", "test@test.com")
+	run(repoDir, "git", "config", "user.name", "Test")
+	run(repoDir, "git", "commit", "--allow-empty", "-m", "initial")
+
+	s := NewWorktreeService()
+	if _, err := s.CreateWorktree(repoDir, "feature-one"); err != nil {
+		t.Fatalf("CreateWorktree() error = %v", err)
+	}
+
+	t.Run("mainWorktree", func(t *testing.T) {
+		path, err := s.WorktreePath(repoDir, "myproject")
+		if err != nil {
+			t.Fatalf("WorktreePath() error = %v", err)
+		}
+		if path != repoDir {
+			t.Fatalf("WorktreePath() = %q, want %q", path, repoDir)
+		}
+	})
+
+	t.Run("found", func(t *testing.T) {
+		path, err := s.WorktreePath(repoDir, "feature-one")
+		if err != nil {
+			t.Fatalf("WorktreePath() error = %v", err)
+		}
+		expectedPath := filepath.Join(tmpDir, "myproject-feature-one")
+		if path != expectedPath {
+			t.Fatalf("WorktreePath() = %q, want %q", path, expectedPath)
+		}
+	})
+
+	t.Run("notFound", func(t *testing.T) {
+		_, err := s.WorktreePath(repoDir, "nonexistent")
+		if err == nil {
+			t.Fatalf("WorktreePath() expected error for nonexistent worktree")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Fatalf("WorktreePath() error = %q, want 'not found'", err.Error())
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -79,8 +79,8 @@ func run(args []string) {
 		"rm":       controllers.NewRmController(projects, selector, git),
 		"help":     controllers.NewHelpController(),
 		"health":   controllers.NewHealthController(health, config),
-		"worktree": controllers.NewWorktreeController(worktree, worktree, worktree, sessionProvider),
-		"wt":       controllers.NewWorktreeController(worktree, worktree, worktree, sessionProvider),
+		"worktree": controllers.NewWorktreeController(worktree, selector, sessionProvider),
+		"wt":       controllers.NewWorktreeController(worktree, selector, sessionProvider),
 	}
 
 	handler, ok := controllerMap[cmd]


### PR DESCRIPTION
## Summary

- Add `ListWorktrees` and `WorktreePath` service methods for discovering and resolving worktrees
- Add `open` sub-controller with fuzzy select (bare `projman wt`) and direct open (`projman wt <name>`)
- Include base worktree in listing, annotated with `(base)` in the fuzzy selector
- Replace individual worktree interfaces with composed `worktreeManager` interface in the dispatcher
- Add default/fallback routing so unknown subcommands are treated as worktree names

## Test plan

- [x] `projman wt` shows all worktrees (including base) in fuzzy finder, opens session on select
- [x] `projman wt <name>` opens the named worktree directly
- [x] `projman wt` outside a git repo errors
- [x] `go test ./...` passes
- [x] `clint` passes