### PR TITLE
feat: add optional copying of gitignored files to new worktrees

### DIFF
--- a/internal/controllers/worktree.go
+++ b/internal/controllers/worktree.go
@@ -32,7 +32,7 @@ func NewWorktreeController(worktrees worktreeManager, fzf selecter, sessions ses
 	openController := worktree.NewOpenController(worktrees, worktrees, fzf, sessions)
 
 	subcommands := map[string]subcommand{
-		"new":  worktree.NewNewController(worktrees, worktrees, sessions),
+		"new":  worktree.NewNewController(worktrees, sessions),
 		"open": openController,
 	}
 

--- a/internal/controllers/worktree.go
+++ b/internal/controllers/worktree.go
@@ -19,6 +19,8 @@ type worktreeManager interface {
 	CreateWorktree(dir, name string) (string, error)
 	ListWorktrees(dir string) ([]string, error)
 	WorktreePath(dir, name string) (string, error)
+	HasIgnoredFiles(dir string) bool
+	CopyIgnoredFiles(mainPath, worktreePath string) []string
 }
 
 type WorktreeController struct {
@@ -31,7 +33,7 @@ func NewWorktreeController(worktrees worktreeManager, fzf selecter, sessions ses
 	openController := worktree.NewOpenController(worktrees, worktrees, fzf, sessions)
 
 	subcommands := map[string]subcommand{
-		"new":  worktree.NewNewController(worktrees, sessions),
+		"new":  worktree.NewNewController(worktrees, worktrees, sessions),
 		"open": openController,
 	}
 

--- a/internal/controllers/worktree.go
+++ b/internal/controllers/worktree.go
@@ -19,7 +19,6 @@ type worktreeManager interface {
 	CreateWorktree(dir, name string) (string, error)
 	ListWorktrees(dir string) ([]string, error)
 	WorktreePath(dir, name string) (string, error)
-	HasIgnoredFiles(dir string) bool
 	CopyIgnoredFiles(mainPath, worktreePath string) []string
 }
 

--- a/internal/controllers/worktree/new.go
+++ b/internal/controllers/worktree/new.go
@@ -14,7 +14,6 @@ type worktreeCreator interface {
 }
 
 type ignoredFileHandler interface {
-	HasIgnoredFiles(dir string) bool
 	CopyIgnoredFiles(mainPath, worktreePath string) []string
 }
 
@@ -46,7 +45,8 @@ func (c NewController) Handle(projectRoot, projectName string, args []string) er
 		return fmt.Errorf("creating worktree: %v", err.Error())
 	}
 
-	if c.ignoredFiles.HasIgnoredFiles(projectRoot) && ui.Confirm("Copy ignored files to new worktree?") {
+	gitignorePath := filepath.Join(projectRoot, ".gitignore")
+	if _, statErr := os.Stat(gitignorePath); statErr == nil && ui.Confirm("Copy ignored files to new worktree?") {
 		warnings, _ := ui.WithSpinner("copying ignored files...", func() ([]string, error) {
 			return c.ignoredFiles.CopyIgnoredFiles(projectRoot, path), nil
 		})

--- a/internal/controllers/worktree/new.go
+++ b/internal/controllers/worktree/new.go
@@ -3,11 +3,19 @@ package worktree
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
+
+	"github.com/danielronalds/projman/internal/ui"
 )
 
 type worktreeCreator interface {
 	CreateWorktree(dir, name string) (string, error)
+}
+
+type ignoredFileHandler interface {
+	HasIgnoredFiles(dir string) bool
+	CopyIgnoredFiles(mainPath, worktreePath string) []string
 }
 
 type sessionLauncher interface {
@@ -15,12 +23,13 @@ type sessionLauncher interface {
 }
 
 type NewController struct {
-	worktrees worktreeCreator
-	sessions  sessionLauncher
+	worktrees    worktreeCreator
+	ignoredFiles ignoredFileHandler
+	sessions     sessionLauncher
 }
 
-func NewNewController(worktrees worktreeCreator, sessions sessionLauncher) NewController {
-	return NewController{worktrees, sessions}
+func NewNewController(worktrees worktreeCreator, ignoredFiles ignoredFileHandler, sessions sessionLauncher) NewController {
+	return NewController{worktrees, ignoredFiles, sessions}
 }
 
 func (c NewController) Handle(projectRoot, projectName string, args []string) error {
@@ -30,9 +39,20 @@ func (c NewController) Handle(projectRoot, projectName string, args []string) er
 
 	branchName := args[0]
 
-	path, err := c.worktrees.CreateWorktree(projectRoot, branchName)
+	path, err := ui.WithSpinner("creating worktree...", func() (string, error) {
+		return c.worktrees.CreateWorktree(projectRoot, branchName)
+	})
 	if err != nil {
 		return fmt.Errorf("creating worktree: %v", err.Error())
+	}
+
+	if c.ignoredFiles.HasIgnoredFiles(projectRoot) && ui.Confirm("Copy ignored files to new worktree?") {
+		warnings, _ := ui.WithSpinner("copying ignored files...", func() ([]string, error) {
+			return c.ignoredFiles.CopyIgnoredFiles(projectRoot, path), nil
+		})
+		for _, w := range warnings {
+			fmt.Fprintf(os.Stderr, "warning: %s\n", w)
+		}
 	}
 
 	return c.sessions.LaunchSession(filepath.Base(path), path)

--- a/internal/controllers/worktree/new.go
+++ b/internal/controllers/worktree/new.go
@@ -11,9 +11,6 @@ import (
 
 type worktreeCreator interface {
 	CreateWorktree(dir, name string) (string, error)
-}
-
-type ignoredFileHandler interface {
 	CopyIgnoredFiles(mainPath, worktreePath string) []string
 }
 
@@ -22,13 +19,12 @@ type sessionLauncher interface {
 }
 
 type NewController struct {
-	worktrees    worktreeCreator
-	ignoredFiles ignoredFileHandler
-	sessions     sessionLauncher
+	worktrees worktreeCreator
+	sessions  sessionLauncher
 }
 
-func NewNewController(worktrees worktreeCreator, ignoredFiles ignoredFileHandler, sessions sessionLauncher) NewController {
-	return NewController{worktrees, ignoredFiles, sessions}
+func NewNewController(worktrees worktreeCreator, sessions sessionLauncher) NewController {
+	return NewController{worktrees, sessions}
 }
 
 func (c NewController) Handle(projectRoot, projectName string, args []string) error {
@@ -48,7 +44,7 @@ func (c NewController) Handle(projectRoot, projectName string, args []string) er
 	gitignorePath := filepath.Join(projectRoot, ".gitignore")
 	if _, statErr := os.Stat(gitignorePath); statErr == nil && ui.Confirm("Copy ignored files to new worktree?") {
 		warnings, _ := ui.WithSpinner("copying ignored files...", func() ([]string, error) {
-			return c.ignoredFiles.CopyIgnoredFiles(projectRoot, path), nil
+			return c.worktrees.CopyIgnoredFiles(projectRoot, path), nil
 		})
 		for _, w := range warnings {
 			fmt.Fprintf(os.Stderr, "warning: %s\n", w)

--- a/internal/controllers/worktree/new.go
+++ b/internal/controllers/worktree/new.go
@@ -38,7 +38,7 @@ func (c NewController) Handle(projectRoot, projectName string, args []string) er
 		return c.worktrees.CreateWorktree(projectRoot, branchName)
 	})
 	if err != nil {
-		return fmt.Errorf("creating worktree: %v", err.Error())
+		return fmt.Errorf("creating worktree: %v", err)
 	}
 
 	gitignorePath := filepath.Join(projectRoot, ".gitignore")

--- a/internal/controllers/worktree/new_test.go
+++ b/internal/controllers/worktree/new_test.go
@@ -19,12 +19,7 @@ func (m *mockWorktreeCreator) CreateWorktree(dir, name string) (string, error) {
 }
 
 type mockIgnoredFileHandler struct {
-	hasFiles       bool
 	returnWarnings []string
-}
-
-func (m *mockIgnoredFileHandler) HasIgnoredFiles(dir string) bool {
-	return m.hasFiles
 }
 
 func (m *mockIgnoredFileHandler) CopyIgnoredFiles(mainPath, worktreePath string) []string {

--- a/internal/controllers/worktree/new_test.go
+++ b/internal/controllers/worktree/new_test.go
@@ -6,10 +6,11 @@ import (
 )
 
 type mockWorktreeCreator struct {
-	returnPath string
-	returnErr  error
-	calledDir  string
-	calledName string
+	returnPath     string
+	returnErr      error
+	calledDir      string
+	calledName     string
+	returnWarnings []string
 }
 
 func (m *mockWorktreeCreator) CreateWorktree(dir, name string) (string, error) {
@@ -18,11 +19,7 @@ func (m *mockWorktreeCreator) CreateWorktree(dir, name string) (string, error) {
 	return m.returnPath, m.returnErr
 }
 
-type mockIgnoredFileHandler struct {
-	returnWarnings []string
-}
-
-func (m *mockIgnoredFileHandler) CopyIgnoredFiles(mainPath, worktreePath string) []string {
+func (m *mockWorktreeCreator) CopyIgnoredFiles(mainPath, worktreePath string) []string {
 	return m.returnWarnings
 }
 
@@ -42,7 +39,6 @@ func TestNewControllerHandle(t *testing.T) {
 	t.Run("missingName", func(t *testing.T) {
 		controller := NewNewController(
 			&mockWorktreeCreator{},
-			&mockIgnoredFileHandler{},
 			&mockSessionLauncher{},
 		)
 
@@ -60,7 +56,6 @@ func TestNewControllerHandle(t *testing.T) {
 		sessions := &mockSessionLauncher{}
 		controller := NewNewController(
 			worktrees,
-			&mockIgnoredFileHandler{},
 			sessions,
 		)
 

--- a/internal/controllers/worktree/new_test.go
+++ b/internal/controllers/worktree/new_test.go
@@ -18,6 +18,19 @@ func (m *mockWorktreeCreator) CreateWorktree(dir, name string) (string, error) {
 	return m.returnPath, m.returnErr
 }
 
+type mockIgnoredFileHandler struct {
+	hasFiles       bool
+	returnWarnings []string
+}
+
+func (m *mockIgnoredFileHandler) HasIgnoredFiles(dir string) bool {
+	return m.hasFiles
+}
+
+func (m *mockIgnoredFileHandler) CopyIgnoredFiles(mainPath, worktreePath string) []string {
+	return m.returnWarnings
+}
+
 type mockSessionLauncher struct {
 	returnErr  error
 	calledName string
@@ -32,7 +45,11 @@ func (m *mockSessionLauncher) LaunchSession(name, dir string) error {
 
 func TestNewControllerHandle(t *testing.T) {
 	t.Run("missingName", func(t *testing.T) {
-		controller := NewNewController(&mockWorktreeCreator{}, &mockSessionLauncher{})
+		controller := NewNewController(
+			&mockWorktreeCreator{},
+			&mockIgnoredFileHandler{},
+			&mockSessionLauncher{},
+		)
 
 		err := controller.Handle("/projects/myapp", "myapp", []string{})
 		if err == nil {
@@ -46,7 +63,11 @@ func TestNewControllerHandle(t *testing.T) {
 	t.Run("successfulCreate", func(t *testing.T) {
 		worktrees := &mockWorktreeCreator{returnPath: "/projects/myapp-feature-auth"}
 		sessions := &mockSessionLauncher{}
-		controller := NewNewController(worktrees, sessions)
+		controller := NewNewController(
+			worktrees,
+			&mockIgnoredFileHandler{},
+			sessions,
+		)
 
 		err := controller.Handle("/projects/myapp", "myapp", []string{"feature/auth"})
 		if err != nil {

--- a/internal/services/worktree.go
+++ b/internal/services/worktree.go
@@ -132,7 +132,7 @@ func listIgnoredPaths(dir string) ([]string, error) {
 	cmd.Dir = dir
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("git ls-files: %v", err.Error())
+		return nil, fmt.Errorf("git ls-files: %v", err)
 	}
 
 	var paths []string
@@ -156,7 +156,7 @@ func copyPath(src, dst string) error {
 
 	dstDir := filepath.Dir(dst)
 	if err := os.MkdirAll(dstDir, 0755); err != nil {
-		return fmt.Errorf("creating parent directory: %v", err.Error())
+		return fmt.Errorf("creating parent directory: %v", err)
 	}
 
 	cmd := exec.Command("cp", "-a", src, dst)
@@ -170,7 +170,7 @@ func copyPath(src, dst string) error {
 func (s WorktreeService) CopyIgnoredFiles(mainPath, worktreePath string) []string {
 	paths, err := listIgnoredPaths(mainPath)
 	if err != nil {
-		return []string{fmt.Sprintf("listing ignored files: %v", err.Error())}
+		return []string{fmt.Sprintf("listing ignored files: %v", err)}
 	}
 
 	var warnings []string
@@ -191,7 +191,7 @@ func (s WorktreeService) CopyIgnoredFiles(mainPath, worktreePath string) []strin
 
 			if err := copyPath(src, dst); err != nil {
 				mu.Lock()
-				warnings = append(warnings, fmt.Sprintf("copying %s: %v", relPath, err.Error()))
+				warnings = append(warnings, fmt.Sprintf("copying %s: %v", relPath, err))
 				mu.Unlock()
 			}
 		}(relPath)

--- a/internal/services/worktree.go
+++ b/internal/services/worktree.go
@@ -145,6 +145,7 @@ func listIgnoredPaths(dir string) ([]string, error) {
 	return paths, nil
 }
 
+// NOTE: cp -a is not available on Windows
 func copyPath(src, dst string) error {
 	src = strings.TrimSuffix(src, string(filepath.Separator))
 	dst = strings.TrimSuffix(dst, string(filepath.Separator))
@@ -166,11 +167,6 @@ func copyPath(src, dst string) error {
 	return nil
 }
 
-func (s WorktreeService) HasIgnoredFiles(dir string) bool {
-	paths, err := listIgnoredPaths(dir)
-	return err == nil && len(paths) > 0
-}
-
 func (s WorktreeService) CopyIgnoredFiles(mainPath, worktreePath string) []string {
 	paths, err := listIgnoredPaths(mainPath)
 	if err != nil {
@@ -180,11 +176,16 @@ func (s WorktreeService) CopyIgnoredFiles(mainPath, worktreePath string) []strin
 	var warnings []string
 	var mu sync.Mutex
 	var wg sync.WaitGroup
+	semaphore := make(chan struct{}, 8)
 
 	for _, relPath := range paths {
 		wg.Add(1)
 		go func(relPath string) {
 			defer wg.Done()
+			// Limit concurrent cp processes to avoid exhausting OS resources
+			semaphore <- struct{}{}
+			defer func() { <-semaphore }()
+
 			src := filepath.Join(mainPath, relPath)
 			dst := filepath.Join(worktreePath, relPath)
 

--- a/internal/services/worktree.go
+++ b/internal/services/worktree.go
@@ -2,10 +2,12 @@ package services
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 )
 
 type WorktreeService struct{}
@@ -123,6 +125,79 @@ func resolveContext(dir string) (mainPath, projectName string, paths []string, e
 	mainPath = paths[0]
 	projectName = filepath.Base(mainPath)
 	return mainPath, projectName, paths, nil
+}
+
+func listIgnoredPaths(dir string) ([]string, error) {
+	cmd := exec.Command("git", "ls-files", "--ignored", "--exclude-standard", "--others", "--directory")
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git ls-files: %v", err.Error())
+	}
+
+	var paths []string
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if line == "" {
+			continue
+		}
+		paths = append(paths, line)
+	}
+	return paths, nil
+}
+
+func copyPath(src, dst string) error {
+	src = strings.TrimSuffix(src, string(filepath.Separator))
+	dst = strings.TrimSuffix(dst, string(filepath.Separator))
+
+	if _, err := os.Stat(src); os.IsNotExist(err) {
+		return nil
+	}
+
+	dstDir := filepath.Dir(dst)
+	if err := os.MkdirAll(dstDir, 0755); err != nil {
+		return fmt.Errorf("creating parent directory: %v", err.Error())
+	}
+
+	cmd := exec.Command("cp", "-a", src, dst)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v", strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func (s WorktreeService) HasIgnoredFiles(dir string) bool {
+	paths, err := listIgnoredPaths(dir)
+	return err == nil && len(paths) > 0
+}
+
+func (s WorktreeService) CopyIgnoredFiles(mainPath, worktreePath string) []string {
+	paths, err := listIgnoredPaths(mainPath)
+	if err != nil {
+		return []string{fmt.Sprintf("listing ignored files: %v", err.Error())}
+	}
+
+	var warnings []string
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, relPath := range paths {
+		wg.Add(1)
+		go func(relPath string) {
+			defer wg.Done()
+			src := filepath.Join(mainPath, relPath)
+			dst := filepath.Join(worktreePath, relPath)
+
+			if err := copyPath(src, dst); err != nil {
+				mu.Lock()
+				warnings = append(warnings, fmt.Sprintf("copying %s: %v", relPath, err.Error()))
+				mu.Unlock()
+			}
+		}(relPath)
+	}
+
+	wg.Wait()
+	return warnings
 }
 
 var nonAlphanumericDashDotUnderscore = regexp.MustCompile(`[^a-zA-Z0-9\-._]`)

--- a/internal/services/worktree_test.go
+++ b/internal/services/worktree_test.go
@@ -149,6 +149,7 @@ func TestCreateWorktree(t *testing.T) {
 			t.Fatalf("expected error for invalid name, got nil")
 		}
 	})
+
 }
 
 func TestListWorktrees(t *testing.T) {
@@ -286,6 +287,147 @@ func TestWorktreePath(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "not found") {
 			t.Fatalf("WorktreePath() error = %q, want 'not found'", err.Error())
+		}
+	})
+}
+
+func TestCopyIgnoredFiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	s := NewWorktreeService()
+
+	type testHelpers struct {
+		run   func(dir string, args ...string)
+		mkdir func(path string)
+		write func(path, content string)
+	}
+
+	setupRepo := func(t *testing.T) (repoDir string, tmpDir string, h testHelpers) {
+		t.Helper()
+		tmpDir, _ = filepath.EvalSymlinks(t.TempDir())
+		repoDir = filepath.Join(tmpDir, "myproject")
+		if err := os.MkdirAll(repoDir, 0755); err != nil {
+			t.Fatalf("failed to create repo dir: %v", err)
+		}
+
+		h.run = func(dir string, args ...string) {
+			t.Helper()
+			cmd := exec.Command(args[0], args[1:]...)
+			cmd.Dir = dir
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("command %v failed: %v\n%s", args, err, output)
+			}
+		}
+
+		h.mkdir = func(path string) {
+			t.Helper()
+			if err := os.MkdirAll(path, 0755); err != nil {
+				t.Fatalf("failed to create directory %s: %v", path, err)
+			}
+		}
+
+		h.write = func(path, content string) {
+			t.Helper()
+			if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+				t.Fatalf("failed to write file %s: %v", path, err)
+			}
+		}
+
+		h.run(repoDir, "git", "init")
+		h.run(repoDir, "git", "config", "user.email", "test@test.com")
+		h.run(repoDir, "git", "config", "user.name", "Test")
+		h.run(repoDir, "git", "commit", "--allow-empty", "-m", "initial")
+		return repoDir, tmpDir, h
+	}
+
+	t.Run("noGitignore", func(t *testing.T) {
+		repoDir, tmpDir, h := setupRepo(t)
+		worktreePath := filepath.Join(tmpDir, "myproject-test")
+
+		h.mkdir(worktreePath)
+		warnings := s.CopyIgnoredFiles(repoDir, worktreePath)
+		if len(warnings) != 0 {
+			t.Fatalf("expected no warnings, got %v", warnings)
+		}
+	})
+
+	t.Run("ignoredFileCopied", func(t *testing.T) {
+		repoDir, tmpDir, h := setupRepo(t)
+
+		h.write(filepath.Join(repoDir, ".gitignore"), "*.log\n")
+		h.write(filepath.Join(repoDir, "debug.log"), "log content")
+		h.run(repoDir, "git", "add", ".gitignore")
+		h.run(repoDir, "git", "commit", "-m", "add gitignore")
+
+		worktreePath := filepath.Join(tmpDir, "myproject-test")
+		h.mkdir(worktreePath)
+
+		warnings := s.CopyIgnoredFiles(repoDir, worktreePath)
+		if len(warnings) != 0 {
+			t.Fatalf("expected no warnings, got %v", warnings)
+		}
+
+		content, err := os.ReadFile(filepath.Join(worktreePath, "debug.log"))
+		if err != nil {
+			t.Fatalf("expected debug.log to be copied, got error: %v", err)
+		}
+		if string(content) != "log content" {
+			t.Fatalf("debug.log content = %q, want %q", string(content), "log content")
+		}
+	})
+
+	t.Run("ignoredDirectoryCopied", func(t *testing.T) {
+		repoDir, tmpDir, h := setupRepo(t)
+
+		h.write(filepath.Join(repoDir, ".gitignore"), "node_modules/\n")
+		h.mkdir(filepath.Join(repoDir, "node_modules", "pkg"))
+		h.write(filepath.Join(repoDir, "node_modules", "pkg", "index.js"), "module.exports = {}")
+		h.run(repoDir, "git", "add", ".gitignore")
+		h.run(repoDir, "git", "commit", "-m", "add gitignore")
+
+		worktreePath := filepath.Join(tmpDir, "myproject-test")
+		h.mkdir(worktreePath)
+
+		warnings := s.CopyIgnoredFiles(repoDir, worktreePath)
+		if len(warnings) != 0 {
+			t.Fatalf("expected no warnings, got %v", warnings)
+		}
+
+		content, err := os.ReadFile(filepath.Join(worktreePath, "node_modules", "pkg", "index.js"))
+		if err != nil {
+			t.Fatalf("expected node_modules/pkg/index.js to be copied, got error: %v", err)
+		}
+		if string(content) != "module.exports = {}" {
+			t.Fatalf("index.js content = %q, want %q", string(content), "module.exports = {}")
+		}
+	})
+
+	t.Run("nestedGitignore", func(t *testing.T) {
+		repoDir, tmpDir, h := setupRepo(t)
+
+		h.mkdir(filepath.Join(repoDir, "subdir"))
+		h.write(filepath.Join(repoDir, "subdir", ".gitignore"), "*.tmp\n")
+		h.write(filepath.Join(repoDir, "subdir", "cache.tmp"), "cached")
+		h.run(repoDir, "git", "add", "subdir/.gitignore")
+		h.run(repoDir, "git", "commit", "-m", "add nested gitignore")
+
+		worktreePath := filepath.Join(tmpDir, "myproject-test")
+		h.mkdir(worktreePath)
+
+		warnings := s.CopyIgnoredFiles(repoDir, worktreePath)
+		if len(warnings) != 0 {
+			t.Fatalf("expected no warnings, got %v", warnings)
+		}
+
+		content, err := os.ReadFile(filepath.Join(worktreePath, "subdir", "cache.tmp"))
+		if err != nil {
+			t.Fatalf("expected subdir/cache.tmp to be copied, got error: %v", err)
+		}
+		if string(content) != "cached" {
+			t.Fatalf("cache.tmp content = %q, want %q", string(content), "cached")
 		}
 	})
 }

--- a/internal/services/worktree_test.go
+++ b/internal/services/worktree_test.go
@@ -149,7 +149,6 @@ func TestCreateWorktree(t *testing.T) {
 			t.Fatalf("expected error for invalid name, got nil")
 		}
 	})
-
 }
 
 func TestListWorktrees(t *testing.T) {

--- a/internal/ui/confirm.go
+++ b/internal/ui/confirm.go
@@ -1,0 +1,17 @@
+package ui
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func Confirm(prompt string) bool {
+	fmt.Printf("%s [y/N] ", prompt)
+	scanner := bufio.NewScanner(os.Stdin)
+	if !scanner.Scan() {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(scanner.Text()), "y")
+}


### PR DESCRIPTION
## Summary

- Adds the ability to copy gitignored files (node_modules, .env, build artifacts, etc.) into newly created worktrees so they are immediately usable
- After `projman wt new <name>`, users are prompted to copy ignored files if any exist
- Copies run concurrently via goroutines with a spinner for feedback
- Uses `git ls-files --ignored --exclude-standard --others --directory` to find ignored paths and `cp -a` for cross-platform copying

## Test plan

- [x] Run `projman wt new test-feature` in a repo with `.gitignore` and ignored files, confirm prompt appears and files are copied
- [x] Run `projman wt new test-feature` in a repo with no `.gitignore`, confirm no prompt appears
- [x] Decline the copy prompt, confirm worktree is created without ignored files
- [x] Verify `go test -short ./...` passes
- [x] Verify `clint` CI pipeline passes (formatting, vet, static analysis)