### PR TITLE
feat: add wt checkout subcommand

### DIFF
--- a/docs/worktree-implementation-plan.md
+++ b/docs/worktree-implementation-plan.md
@@ -161,7 +161,7 @@ Handle: if no args, list -> select -> open. If args, treat as direct name -> res
 
 ## Stage 3: `checkout` command
 
-- [ ] Complete
+- [x] Complete
 
 Adds fetching remote branches and checking them out into worktrees.
 

--- a/internal/controllers/worktree.go
+++ b/internal/controllers/worktree.go
@@ -20,6 +20,8 @@ type worktreeManager interface {
 	ListWorktrees(dir string) ([]string, error)
 	WorktreePath(dir, name string) (string, error)
 	CopyIgnoredFiles(mainPath, worktreePath string) []string
+	ListRemoteBranches(dir string) ([]string, error)
+	CheckoutWorktree(dir, remoteBranch string) (string, error)
 }
 
 type WorktreeController struct {
@@ -32,8 +34,9 @@ func NewWorktreeController(worktrees worktreeManager, fzf selecter, sessions ses
 	openController := worktree.NewOpenController(worktrees, worktrees, fzf, sessions)
 
 	subcommands := map[string]subcommand{
-		"new":  worktree.NewNewController(worktrees, sessions),
-		"open": openController,
+		"new":      worktree.NewNewController(worktrees, sessions),
+		"open":     openController,
+		"checkout": worktree.NewCheckoutController(worktrees, worktrees, fzf, sessions),
 	}
 
 	return WorktreeController{worktrees, subcommands, openController}

--- a/internal/controllers/worktree/checkout.go
+++ b/internal/controllers/worktree/checkout.go
@@ -1,0 +1,67 @@
+package worktree
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/danielronalds/projman/internal/ui"
+)
+
+type remoteBranchLister interface {
+	ListRemoteBranches(dir string) ([]string, error)
+}
+
+type worktreeCheckout interface {
+	CheckoutWorktree(dir, remoteBranch string) (string, error)
+	CopyIgnoredFiles(mainPath, worktreePath string) []string
+}
+
+type CheckoutController struct {
+	branches remoteBranchLister
+	checkout worktreeCheckout
+	fzf      selecter
+	sessions sessionLauncher
+}
+
+func NewCheckoutController(branches remoteBranchLister, checkout worktreeCheckout, fzf selecter, sessions sessionLauncher) CheckoutController {
+	return CheckoutController{branches, checkout, fzf, sessions}
+}
+
+func (c CheckoutController) Handle(projectRoot, projectName string, args []string) error {
+	branches, err := ui.WithSpinner("fetching remote branches...", func() ([]string, error) {
+		return c.branches.ListRemoteBranches(projectRoot)
+	})
+	if err != nil {
+		return fmt.Errorf("listing remote branches: %v", err)
+	}
+
+	if len(branches) == 0 {
+		return errors.New("no remote branches found")
+	}
+
+	selected, err := c.fzf.Select(branches)
+	if err != nil {
+		return errors.New("no branch selected")
+	}
+
+	path, err := ui.WithSpinner("checking out worktree...", func() (string, error) {
+		return c.checkout.CheckoutWorktree(projectRoot, selected)
+	})
+	if err != nil {
+		return fmt.Errorf("checking out worktree: %v", err)
+	}
+
+	gitignorePath := filepath.Join(projectRoot, ".gitignore")
+	if _, statErr := os.Stat(gitignorePath); statErr == nil && ui.Confirm("Copy ignored files to new worktree?") {
+		warnings, _ := ui.WithSpinner("copying ignored files...", func() ([]string, error) {
+			return c.checkout.CopyIgnoredFiles(projectRoot, path), nil
+		})
+		for _, w := range warnings {
+			fmt.Fprintf(os.Stderr, "warning: %s\n", w)
+		}
+	}
+
+	return c.sessions.LaunchSession(filepath.Base(path), path)
+}

--- a/internal/controllers/worktree/checkout_test.go
+++ b/internal/controllers/worktree/checkout_test.go
@@ -1,0 +1,135 @@
+package worktree
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type mockRemoteBranchLister struct {
+	returnBranches []string
+	returnErr      error
+	calledDir      string
+}
+
+func (m *mockRemoteBranchLister) ListRemoteBranches(dir string) ([]string, error) {
+	m.calledDir = dir
+	return m.returnBranches, m.returnErr
+}
+
+type mockWorktreeCheckout struct {
+	returnPath     string
+	returnErr      error
+	calledDir      string
+	calledBranch   string
+	returnWarnings []string
+}
+
+func (m *mockWorktreeCheckout) CheckoutWorktree(dir, remoteBranch string) (string, error) {
+	m.calledDir = dir
+	m.calledBranch = remoteBranch
+	return m.returnPath, m.returnErr
+}
+
+func (m *mockWorktreeCheckout) CopyIgnoredFiles(mainPath, worktreePath string) []string {
+	return m.returnWarnings
+}
+
+func TestCheckoutControllerHandle(t *testing.T) {
+	t.Run("noRemoteBranches", func(t *testing.T) {
+		branches := &mockRemoteBranchLister{returnBranches: nil}
+		checkout := &mockWorktreeCheckout{}
+		fzf := &mockSelecter{}
+		sessions := &mockSessionLauncher{}
+
+		controller := NewCheckoutController(branches, checkout, fzf, sessions)
+		err := controller.Handle("/projects/myapp", "myapp", nil)
+
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "no remote branches found") {
+			t.Fatalf("expected 'no remote branches found' error, got: %v", err)
+		}
+	})
+
+	t.Run("fetchError", func(t *testing.T) {
+		branches := &mockRemoteBranchLister{returnErr: errors.New("fetch failed")}
+		checkout := &mockWorktreeCheckout{}
+		fzf := &mockSelecter{}
+		sessions := &mockSessionLauncher{}
+
+		controller := NewCheckoutController(branches, checkout, fzf, sessions)
+		err := controller.Handle("/projects/myapp", "myapp", nil)
+
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "listing remote branches") {
+			t.Fatalf("expected 'listing remote branches' error, got: %v", err)
+		}
+	})
+
+	t.Run("selectionCancelled", func(t *testing.T) {
+		branches := &mockRemoteBranchLister{returnBranches: []string{"origin/main", "origin/feature/auth"}}
+		checkout := &mockWorktreeCheckout{}
+		fzf := &mockSelecter{returnErr: errors.New("cancelled")}
+		sessions := &mockSessionLauncher{}
+
+		controller := NewCheckoutController(branches, checkout, fzf, sessions)
+		err := controller.Handle("/projects/myapp", "myapp", nil)
+
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "no branch selected") {
+			t.Fatalf("expected 'no branch selected' error, got: %v", err)
+		}
+	})
+
+	t.Run("checkoutError", func(t *testing.T) {
+		branches := &mockRemoteBranchLister{returnBranches: []string{"origin/main"}}
+		checkout := &mockWorktreeCheckout{returnErr: errors.New("worktree already exists")}
+		fzf := &mockSelecter{returnSelected: "origin/main"}
+		sessions := &mockSessionLauncher{}
+
+		controller := NewCheckoutController(branches, checkout, fzf, sessions)
+		err := controller.Handle("/projects/myapp", "myapp", nil)
+
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "checking out worktree") {
+			t.Fatalf("expected 'checking out worktree' error, got: %v", err)
+		}
+	})
+
+	t.Run("successfulCheckout", func(t *testing.T) {
+		branches := &mockRemoteBranchLister{returnBranches: []string{"origin/main", "origin/feature/auth"}}
+		checkout := &mockWorktreeCheckout{returnPath: "/projects/myapp-feature-auth"}
+		fzf := &mockSelecter{returnSelected: "origin/feature/auth"}
+		sessions := &mockSessionLauncher{}
+
+		controller := NewCheckoutController(branches, checkout, fzf, sessions)
+		err := controller.Handle("/projects/myapp", "myapp", nil)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if branches.calledDir != "/projects/myapp" {
+			t.Fatalf("ListRemoteBranches dir = %q, want %q", branches.calledDir, "/projects/myapp")
+		}
+		if checkout.calledDir != "/projects/myapp" {
+			t.Fatalf("CheckoutWorktree dir = %q, want %q", checkout.calledDir, "/projects/myapp")
+		}
+		if checkout.calledBranch != "origin/feature/auth" {
+			t.Fatalf("CheckoutWorktree branch = %q, want %q", checkout.calledBranch, "origin/feature/auth")
+		}
+		if sessions.calledName != "myapp-feature-auth" {
+			t.Fatalf("LaunchSession name = %q, want %q", sessions.calledName, "myapp-feature-auth")
+		}
+		if sessions.calledDir != "/projects/myapp-feature-auth" {
+			t.Fatalf("LaunchSession dir = %q, want %q", sessions.calledDir, "/projects/myapp-feature-auth")
+		}
+	})
+}

--- a/internal/controllers/worktree/mocks_test.go
+++ b/internal/controllers/worktree/mocks_test.go
@@ -1,0 +1,24 @@
+package worktree
+
+type mockSessionLauncher struct {
+	returnErr  error
+	calledName string
+	calledDir  string
+}
+
+func (m *mockSessionLauncher) LaunchSession(name, dir string) error {
+	m.calledName = name
+	m.calledDir = dir
+	return m.returnErr
+}
+
+type mockSelecter struct {
+	returnSelected string
+	returnErr      error
+	calledOptions  []string
+}
+
+func (m *mockSelecter) Select(options []string) (string, error) {
+	m.calledOptions = options
+	return m.returnSelected, m.returnErr
+}

--- a/internal/controllers/worktree/new_test.go
+++ b/internal/controllers/worktree/new_test.go
@@ -23,18 +23,6 @@ func (m *mockWorktreeCreator) CopyIgnoredFiles(mainPath, worktreePath string) []
 	return m.returnWarnings
 }
 
-type mockSessionLauncher struct {
-	returnErr  error
-	calledName string
-	calledDir  string
-}
-
-func (m *mockSessionLauncher) LaunchSession(name, dir string) error {
-	m.calledName = name
-	m.calledDir = dir
-	return m.returnErr
-}
-
 func TestNewControllerHandle(t *testing.T) {
 	t.Run("missingName", func(t *testing.T) {
 		controller := NewNewController(

--- a/internal/controllers/worktree/open_test.go
+++ b/internal/controllers/worktree/open_test.go
@@ -30,16 +30,6 @@ func (m *mockWorktreePathFinder) WorktreePath(dir, name string) (string, error) 
 	return m.returnPath, m.returnErr
 }
 
-type mockSelecter struct {
-	returnSelected string
-	returnErr      error
-	calledOptions  []string
-}
-
-func (m *mockSelecter) Select(options []string) (string, error) {
-	m.calledOptions = options
-	return m.returnSelected, m.returnErr
-}
 
 func TestOpenControllerHandle(t *testing.T) {
 	t.Run("noWorktreesExist", func(t *testing.T) {

--- a/internal/controllers/worktree/open_test.go
+++ b/internal/controllers/worktree/open_test.go
@@ -30,7 +30,6 @@ func (m *mockWorktreePathFinder) WorktreePath(dir, name string) (string, error) 
 	return m.returnPath, m.returnErr
 }
 
-
 func TestOpenControllerHandle(t *testing.T) {
 	t.Run("noWorktreesExist", func(t *testing.T) {
 		lister := &mockWorktreeLister{returnNames: nil}

--- a/internal/services/worktree.go
+++ b/internal/services/worktree.go
@@ -201,6 +201,63 @@ func (s WorktreeService) CopyIgnoredFiles(mainPath, worktreePath string) []strin
 	return warnings
 }
 
+func (s WorktreeService) ListRemoteBranches(dir string) ([]string, error) {
+	fetchCmd := exec.Command("git", "fetch", "--all", "--prune")
+	fetchCmd.Dir = dir
+	if output, err := fetchCmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("fetching remotes: %v", strings.TrimSpace(string(output)))
+	}
+
+	branchCmd := exec.Command("git", "branch", "-r", "--format=%(refname:short)")
+	branchCmd.Dir = dir
+	output, err := branchCmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("listing remote branches: %v", err.Error())
+	}
+
+	var branches []string
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if line == "" || strings.Contains(line, "HEAD") {
+			continue
+		}
+		branches = append(branches, line)
+	}
+	return branches, nil
+}
+
+func (s WorktreeService) CheckoutWorktree(dir, remoteBranch string) (string, error) {
+	mainPath, projectName, _, err := resolveContext(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolving git context: %v", err.Error())
+	}
+
+	parts := strings.SplitN(remoteBranch, "/", 2)
+	if len(parts) < 2 {
+		return "", fmt.Errorf("invalid remote branch %q: expected format <remote>/<branch>", remoteBranch)
+	}
+	localBranch := parts[1]
+
+	sanitised := sanitiseForDirectory(localBranch)
+	if sanitised == "" {
+		return "", fmt.Errorf("invalid branch name %q: results in empty directory name after sanitisation", remoteBranch)
+	}
+
+	dirName := projectName + "-" + sanitised
+	worktreePath := filepath.Join(filepath.Dir(mainPath), dirName)
+
+	cmd := exec.Command("git", "worktree", "add", worktreePath, remoteBranch)
+	cmd.Dir = mainPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if _, statErr := os.Stat(worktreePath); statErr == nil {
+			return worktreePath, nil
+		}
+		return "", fmt.Errorf("checking out worktree: %v", strings.TrimSpace(string(output)))
+	}
+
+	return worktreePath, nil
+}
+
 var nonAlphanumericDashDotUnderscore = regexp.MustCompile(`[^a-zA-Z0-9\-._]`)
 var multipleDashes = regexp.MustCompile(`-{2,}`)
 

--- a/internal/services/worktree.go
+++ b/internal/services/worktree.go
@@ -245,7 +245,7 @@ func (s WorktreeService) CheckoutWorktree(dir, remoteBranch string) (string, err
 	dirName := projectName + "-" + sanitised
 	worktreePath := filepath.Join(filepath.Dir(mainPath), dirName)
 
-	cmd := exec.Command("git", "worktree", "add", worktreePath, remoteBranch)
+	cmd := exec.Command("git", "worktree", "add", worktreePath, localBranch)
 	cmd.Dir = mainPath
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/services/worktree_test.go
+++ b/internal/services/worktree_test.go
@@ -290,6 +290,131 @@ func TestWorktreePath(t *testing.T) {
 	})
 }
 
+func TestListRemoteBranches(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tmpDir, _ := filepath.EvalSymlinks(t.TempDir())
+	remoteDir := filepath.Join(tmpDir, "remote")
+	repoDir := filepath.Join(tmpDir, "myproject")
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, output)
+		}
+	}
+
+	run(tmpDir, "git", "init", remoteDir)
+	run(remoteDir, "git", "config", "user.email", "test@test.com")
+	run(remoteDir, "git", "config", "user.name", "Test")
+	run(remoteDir, "git", "commit", "--allow-empty", "-m", "initial")
+	run(remoteDir, "git", "checkout", "-b", "feature/test-branch")
+	run(remoteDir, "git", "commit", "--allow-empty", "-m", "feature commit")
+	run(tmpDir, "git", "clone", remoteDir, repoDir)
+
+	s := NewWorktreeService()
+
+	t.Run("includesRemoteBranches", func(t *testing.T) {
+		branches, err := s.ListRemoteBranches(repoDir)
+		if err != nil {
+			t.Fatalf("ListRemoteBranches() error = %v", err)
+		}
+		found := false
+		for _, b := range branches {
+			if b == "origin/feature/test-branch" {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected 'origin/feature/test-branch' in branches, got %v", branches)
+		}
+	})
+
+	t.Run("excludesHead", func(t *testing.T) {
+		branches, err := s.ListRemoteBranches(repoDir)
+		if err != nil {
+			t.Fatalf("ListRemoteBranches() error = %v", err)
+		}
+		for _, b := range branches {
+			if strings.Contains(b, "HEAD") {
+				t.Fatalf("expected HEAD to be filtered out, got %q in branches", b)
+			}
+		}
+	})
+}
+
+func TestCheckoutWorktree(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tmpDir, _ := filepath.EvalSymlinks(t.TempDir())
+	remoteDir := filepath.Join(tmpDir, "remote")
+	repoDir := filepath.Join(tmpDir, "myproject")
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, output)
+		}
+	}
+
+	run(tmpDir, "git", "init", remoteDir)
+	run(remoteDir, "git", "config", "user.email", "test@test.com")
+	run(remoteDir, "git", "config", "user.name", "Test")
+	run(remoteDir, "git", "commit", "--allow-empty", "-m", "initial")
+	run(remoteDir, "git", "checkout", "-b", "feature/test-branch")
+	run(remoteDir, "git", "commit", "--allow-empty", "-m", "feature commit")
+	run(tmpDir, "git", "clone", remoteDir, repoDir)
+
+	s := NewWorktreeService()
+
+	t.Run("checkoutRemoteBranch", func(t *testing.T) {
+		path, err := s.CheckoutWorktree(repoDir, "origin/feature/test-branch")
+		if err != nil {
+			t.Fatalf("CheckoutWorktree() error = %v", err)
+		}
+
+		expectedPath := filepath.Join(tmpDir, "myproject-feature-test-branch")
+		if path != expectedPath {
+			t.Fatalf("CheckoutWorktree() path = %q, want %q", path, expectedPath)
+		}
+
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Fatalf("worktree directory does not exist at %q", path)
+		}
+	})
+
+	t.Run("alreadyCheckedOut", func(t *testing.T) {
+		path1, err := s.CheckoutWorktree(repoDir, "origin/feature/test-branch")
+		if err != nil {
+			t.Fatalf("first CheckoutWorktree() error = %v", err)
+		}
+		path2, err := s.CheckoutWorktree(repoDir, "origin/feature/test-branch")
+		if err != nil {
+			t.Fatalf("second CheckoutWorktree() error = %v", err)
+		}
+		if path1 != path2 {
+			t.Fatalf("second CheckoutWorktree() path = %q, want %q", path2, path1)
+		}
+	})
+
+	t.Run("invalidRemoteBranch", func(t *testing.T) {
+		_, err := s.CheckoutWorktree(repoDir, "noslash")
+		if err == nil {
+			t.Fatalf("expected error for branch with no remote prefix, got nil")
+		}
+	})
+}
+
 func TestCopyIgnoredFiles(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")

--- a/internal/services/worktree_test.go
+++ b/internal/services/worktree_test.go
@@ -290,14 +290,11 @@ func TestWorktreePath(t *testing.T) {
 	})
 }
 
-func TestListRemoteBranches(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-
-	tmpDir, _ := filepath.EvalSymlinks(t.TempDir())
+func setupRemoteAndClone(t *testing.T) (repoDir, tmpDir string) {
+	t.Helper()
+	tmpDir, _ = filepath.EvalSymlinks(t.TempDir())
 	remoteDir := filepath.Join(tmpDir, "remote")
-	repoDir := filepath.Join(tmpDir, "myproject")
+	repoDir = filepath.Join(tmpDir, "myproject")
 
 	run := func(dir string, args ...string) {
 		t.Helper()
@@ -313,10 +310,18 @@ func TestListRemoteBranches(t *testing.T) {
 	run(remoteDir, "git", "config", "user.email", "test@test.com")
 	run(remoteDir, "git", "config", "user.name", "Test")
 	run(remoteDir, "git", "commit", "--allow-empty", "-m", "initial")
-	run(remoteDir, "git", "checkout", "-b", "feature/test-branch")
-	run(remoteDir, "git", "commit", "--allow-empty", "-m", "feature commit")
+	run(remoteDir, "git", "branch", "feature/test-branch")
+	run(remoteDir, "git", "branch", "feature/second-branch")
 	run(tmpDir, "git", "clone", remoteDir, repoDir)
+	return repoDir, tmpDir
+}
 
+func TestListRemoteBranches(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	repoDir, _ := setupRemoteAndClone(t)
 	s := NewWorktreeService()
 
 	t.Run("includesRemoteBranches", func(t *testing.T) {
@@ -353,28 +358,7 @@ func TestCheckoutWorktree(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	tmpDir, _ := filepath.EvalSymlinks(t.TempDir())
-	remoteDir := filepath.Join(tmpDir, "remote")
-	repoDir := filepath.Join(tmpDir, "myproject")
-
-	run := func(dir string, args ...string) {
-		t.Helper()
-		cmd := exec.Command(args[0], args[1:]...)
-		cmd.Dir = dir
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("command %v failed: %v\n%s", args, err, output)
-		}
-	}
-
-	run(tmpDir, "git", "init", remoteDir)
-	run(remoteDir, "git", "config", "user.email", "test@test.com")
-	run(remoteDir, "git", "config", "user.name", "Test")
-	run(remoteDir, "git", "commit", "--allow-empty", "-m", "initial")
-	run(remoteDir, "git", "checkout", "-b", "feature/test-branch")
-	run(remoteDir, "git", "commit", "--allow-empty", "-m", "feature commit")
-	run(tmpDir, "git", "clone", remoteDir, repoDir)
-
+	repoDir, tmpDir := setupRemoteAndClone(t)
 	s := NewWorktreeService()
 
 	t.Run("checkoutRemoteBranch", func(t *testing.T) {
@@ -394,11 +378,11 @@ func TestCheckoutWorktree(t *testing.T) {
 	})
 
 	t.Run("alreadyCheckedOut", func(t *testing.T) {
-		path1, err := s.CheckoutWorktree(repoDir, "origin/feature/test-branch")
+		path1, err := s.CheckoutWorktree(repoDir, "origin/feature/second-branch")
 		if err != nil {
 			t.Fatalf("first CheckoutWorktree() error = %v", err)
 		}
-		path2, err := s.CheckoutWorktree(repoDir, "origin/feature/test-branch")
+		path2, err := s.CheckoutWorktree(repoDir, "origin/feature/second-branch")
 		if err != nil {
 			t.Fatalf("second CheckoutWorktree() error = %v", err)
 		}


### PR DESCRIPTION
## Summary

- Adds `projman wt checkout` (alias `projman worktree checkout`) subcommand
- Fetches all remote branches with a spinner, presents them via fuzzy select, creates a worktree tracking the selected branch, and opens a session in it
- Handles the idempotent case: if the worktree directory already exists (branch previously checked out), opens it rather than erroring
- Remote prefix stripping is generalised (`SplitN` on first `/`) so it works for any remote name, not just `origin`

## Changes

- `internal/services/worktree.go` -- `ListRemoteBranches` and `CheckoutWorktree` service methods
- `internal/services/worktree_test.go` -- integration tests using a local clone to avoid any push operations
- `internal/controllers/worktree/checkout.go` -- `CheckoutController` with full fetch → select → checkout → copy ignored files → launch session flow
- `internal/controllers/worktree/checkout_test.go` -- unit tests covering all error paths and happy path
- `internal/controllers/worktree.go` -- extended `worktreeManager` interface, wired `checkout` into subcommands map