### PR TITLE
Add -p short-hand for --provider flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ Commands
 
 ### Global Flags
 
-`--provider <provider>` overrides the configured session provider for a single invocation:
+`--provider, -p <provider>` overrides the configured session provider for a single invocation:
 
 ```console
 projman --provider=vscode local
 projman --provider tmux remote
+projman -p tmux local
 ```
 
 ## Configuration

--- a/main.go
+++ b/main.go
@@ -20,18 +20,18 @@ func parseProviderFlag(args []string) (string, []string, error) {
 	for i := 0; i < len(args); i++ {
 		if args[i] == "--provider" || args[i] == "-p" {
 			if i+1 >= len(args) {
-				return "", nil, fmt.Errorf("--provider/-p requires a value")
+				return "", nil, fmt.Errorf("--provider requires a value")
 			}
 			provider = args[i+1]
 			i++
 		} else if value, ok := strings.CutPrefix(args[i], "--provider="); ok {
 			if value == "" {
-				return "", nil, fmt.Errorf("--provider/-p requires a value")
+				return "", nil, fmt.Errorf("--provider requires a value")
 			}
 			provider = value
 		} else if value, ok := strings.CutPrefix(args[i], "-p="); ok {
 			if value == "" {
-				return "", nil, fmt.Errorf("--provider/-p requires a value")
+				return "", nil, fmt.Errorf("--provider requires a value")
 			}
 			provider = value
 		} else {

--- a/main.go
+++ b/main.go
@@ -18,15 +18,20 @@ func parseProviderFlag(args []string) (string, []string, error) {
 	remaining := make([]string, 0, len(args))
 	provider := ""
 	for i := 0; i < len(args); i++ {
-		if args[i] == "--provider" {
+		if args[i] == "--provider" || args[i] == "-p" {
 			if i+1 >= len(args) {
-				return "", nil, fmt.Errorf("--provider requires a value")
+				return "", nil, fmt.Errorf("--provider/-p requires a value")
 			}
 			provider = args[i+1]
 			i++
 		} else if value, ok := strings.CutPrefix(args[i], "--provider="); ok {
 			if value == "" {
-				return "", nil, fmt.Errorf("--provider requires a value")
+				return "", nil, fmt.Errorf("--provider/-p requires a value")
+			}
+			provider = value
+		} else if value, ok := strings.CutPrefix(args[i], "-p="); ok {
+			if value == "" {
+				return "", nil, fmt.Errorf("--provider/-p requires a value")
 			}
 			provider = value
 		} else {


### PR DESCRIPTION
## Summary
- Adds `-p` as a short-hand alias for the `--provider` flag
- Supports both `-p <value>` and `-p=<value>` forms
- Updates README docs to reflect the new short-hand

## Test plan
- [x] `projman -p tmux local` works
- [x] `projman -p=vscode local` works
- [x] `projman -p` without a value shows error
- [x] Existing `--provider` and `--provider=` forms still work
- [x] All tests pass