### PR TITLE
Add here command to open session in current directory

### DIFF
--- a/internal/controllers/active.go
+++ b/internal/controllers/active.go
@@ -21,15 +21,15 @@ type sessionManager interface {
 type ActiveController struct {
 	projects projectPathFinder
 	fzf      selecter
-	tmux     sessionManager
+	sessions sessionManager
 }
 
-func NewActiveController(projects projectPathFinder, fzf selecter, tmux sessionManager) ActiveController {
-	return ActiveController{projects, fzf, tmux}
+func NewActiveController(projects projectPathFinder, fzf selecter, sessions sessionManager) ActiveController {
+	return ActiveController{projects, fzf, sessions}
 }
 
 func (c ActiveController) HandleArgs(args []string) error {
-	sessions, err := c.tmux.ListActiveSessions()
+	sessions, err := c.sessions.ListActiveSessions()
 	if err != nil {
 		return fmt.Errorf("unable to list active sessions: %v", err.Error())
 	}
@@ -45,5 +45,5 @@ func (c ActiveController) HandleArgs(args []string) error {
 		return errors.New("no session selected")
 	}
 
-	return c.tmux.OpenActiveSession(session)
+	return c.sessions.OpenActiveSession(session)
 }

--- a/internal/controllers/clone.go
+++ b/internal/controllers/clone.go
@@ -12,14 +12,14 @@ type remoteURLCloner interface {
 }
 
 type CloneController struct {
-	remote remoteURLCloner
-	fzf    selecter
-	tmux   sessionLauncher
-	config remoteConfig
+	remote   remoteURLCloner
+	fzf      selecter
+	sessions sessionLauncher
+	config   remoteConfig
 }
 
-func NewCloneController(remote remoteURLCloner, fzf selecter, tmux sessionLauncher, config remoteConfig) CloneController {
-	return CloneController{remote, fzf, tmux, config}
+func NewCloneController(remote remoteURLCloner, fzf selecter, sessions sessionLauncher, config remoteConfig) CloneController {
+	return CloneController{remote, fzf, sessions, config}
 }
 
 func (c CloneController) HandleArgs(args []string) error {
@@ -46,7 +46,7 @@ func (c CloneController) HandleArgs(args []string) error {
 		return fmt.Errorf("unable to clone project: %v", err.Error())
 	}
 
-	return c.tmux.LaunchSession(repoName, projPath)
+	return c.sessions.LaunchSession(repoName, projPath)
 }
 
 var repoNameRegex = regexp.MustCompile(`([\w.-]+)(?:\.git)?$`)

--- a/internal/controllers/directopen.go
+++ b/internal/controllers/directopen.go
@@ -8,11 +8,11 @@ import (
 type DirectOpenController struct {
 	projects openProjectLister
 	fzf      selecter
-	tmux     sessionLauncher
+	sessions sessionLauncher
 }
 
-func NewDirectOpenController(projects openProjectLister, fzf selecter, tmux sessionLauncher) DirectOpenController {
-	return DirectOpenController{projects, fzf, tmux}
+func NewDirectOpenController(projects openProjectLister, fzf selecter, sessions sessionLauncher) DirectOpenController {
+	return DirectOpenController{projects, fzf, sessions}
 }
 
 func (c DirectOpenController) HandleArgs(args []string) error {
@@ -27,5 +27,5 @@ func (c DirectOpenController) HandleArgs(args []string) error {
 		return fmt.Errorf("unable to get project path: %v", err.Error())
 	}
 
-	return c.tmux.LaunchSession(proj, projPath)
+	return c.sessions.LaunchSession(proj, projPath)
 }

--- a/internal/controllers/help.go
+++ b/internal/controllers/help.go
@@ -16,6 +16,7 @@ Commands
   remote    Open a project from github
   clone     Clone any git url to a project dir
   active    Open an existing session
+  here      Open a session in the current directory
   config    Open the projman config in your editor
   rm        Remove a project from your machine
   worktree  Manage git worktrees -- run 'projman wt help' for details (alias: wt)

--- a/internal/controllers/here.go
+++ b/internal/controllers/here.go
@@ -1,0 +1,26 @@
+package controllers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type HereController struct {
+	sessions sessionLauncher
+}
+
+func NewHereController(sessions sessionLauncher) HereController {
+	return HereController{sessions}
+}
+
+func (c HereController) HandleArgs(args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("unable to get current directory: %v", err.Error())
+	}
+
+	name := filepath.Base(cwd)
+
+	return c.sessions.LaunchSession(name, cwd)
+}

--- a/internal/controllers/here.go
+++ b/internal/controllers/here.go
@@ -6,12 +6,17 @@ import (
 	"path/filepath"
 )
 
-type HereController struct {
-	sessions sessionLauncher
+type sessionNameSanitiser interface {
+	Sanitise(name string) string
 }
 
-func NewHereController(sessions sessionLauncher) HereController {
-	return HereController{sessions}
+type HereController struct {
+	sessions  sessionLauncher
+	sanitiser sessionNameSanitiser
+}
+
+func NewHereController(sessions sessionLauncher, sanitiser sessionNameSanitiser) HereController {
+	return HereController{sessions, sanitiser}
 }
 
 func (c HereController) HandleArgs(args []string) error {
@@ -20,7 +25,7 @@ func (c HereController) HandleArgs(args []string) error {
 		return fmt.Errorf("unable to get current directory: %v", err.Error())
 	}
 
-	name := filepath.Base(cwd)
+	name := c.sanitiser.Sanitise(filepath.Base(cwd))
 
 	return c.sessions.LaunchSession(name, cwd)
 }

--- a/internal/controllers/here_test.go
+++ b/internal/controllers/here_test.go
@@ -8,15 +8,15 @@ import (
 )
 
 type mockSessionLauncher struct {
-	launchedName string
-	launchedDir  string
-	err          error
+	calledName string
+	calledDir  string
+	returnErr  error
 }
 
 func (m *mockSessionLauncher) LaunchSession(name, dir string) error {
-	m.launchedName = name
-	m.launchedDir = dir
-	return m.err
+	m.calledName = name
+	m.calledDir = dir
+	return m.returnErr
 }
 
 func TestHereController_HandleArgs(t *testing.T) {
@@ -36,17 +36,17 @@ func TestHereController_HandleArgs(t *testing.T) {
 			t.Fatalf("HandleArgs() error = %v, want nil", err)
 		}
 
-		if mock.launchedName != expectedName {
-			t.Fatalf("LaunchSession name = %q, want %q", mock.launchedName, expectedName)
+		if mock.calledName != expectedName {
+			t.Fatalf("LaunchSession name = %q, want %q", mock.calledName, expectedName)
 		}
 
-		if mock.launchedDir != cwd {
-			t.Fatalf("LaunchSession dir = %q, want %q", mock.launchedDir, cwd)
+		if mock.calledDir != cwd {
+			t.Fatalf("LaunchSession dir = %q, want %q", mock.calledDir, cwd)
 		}
 	})
 
 	t.Run("returns session launcher error", func(t *testing.T) {
-		mock := &mockSessionLauncher{err: fmt.Errorf("session failed")}
+		mock := &mockSessionLauncher{returnErr: fmt.Errorf("session failed")}
 		controller := NewHereController(mock)
 
 		err := controller.HandleArgs([]string{})

--- a/internal/controllers/here_test.go
+++ b/internal/controllers/here_test.go
@@ -19,37 +19,44 @@ func (m *mockSessionLauncher) LaunchSession(name, dir string) error {
 	return m.returnErr
 }
 
-func TestHereController_HandleArgs(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get working directory: %v", err)
-	}
+type mockSanitiser struct{}
 
-	expectedName := filepath.Base(cwd)
+func (m *mockSanitiser) Sanitise(name string) string {
+	return name
+}
+
+func TestHereController_HandleArgs(t *testing.T) {
+	subdir := "test-project"
+	tempDir := filepath.Join(t.TempDir(), subdir)
+	err := os.MkdirAll(tempDir, 0755)
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Chdir(tempDir)
 
 	t.Run("launches session with cwd", func(t *testing.T) {
 		mock := &mockSessionLauncher{}
-		controller := NewHereController(mock)
+		controller := NewHereController(mock, &mockSanitiser{})
 
-		err := controller.HandleArgs([]string{})
+		err := controller.HandleArgs([]string{"here"})
 		if err != nil {
 			t.Fatalf("HandleArgs() error = %v, want nil", err)
 		}
 
-		if mock.calledName != expectedName {
-			t.Fatalf("LaunchSession name = %q, want %q", mock.calledName, expectedName)
+		if mock.calledName != subdir {
+			t.Fatalf("LaunchSession name = %q, want %q", mock.calledName, subdir)
 		}
 
-		if mock.calledDir != cwd {
-			t.Fatalf("LaunchSession dir = %q, want %q", mock.calledDir, cwd)
+		if mock.calledDir != tempDir {
+			t.Fatalf("LaunchSession dir = %q, want %q", mock.calledDir, tempDir)
 		}
 	})
 
 	t.Run("returns session launcher error", func(t *testing.T) {
 		mock := &mockSessionLauncher{returnErr: fmt.Errorf("session failed")}
-		controller := NewHereController(mock)
+		controller := NewHereController(mock, &mockSanitiser{})
 
-		err := controller.HandleArgs([]string{})
+		err := controller.HandleArgs([]string{"here"})
 		if err == nil {
 			t.Fatalf("HandleArgs() error = nil, want error")
 		}

--- a/internal/controllers/here_test.go
+++ b/internal/controllers/here_test.go
@@ -1,0 +1,57 @@
+package controllers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type mockSessionLauncher struct {
+	launchedName string
+	launchedDir  string
+	err          error
+}
+
+func (m *mockSessionLauncher) LaunchSession(name, dir string) error {
+	m.launchedName = name
+	m.launchedDir = dir
+	return m.err
+}
+
+func TestHereController_HandleArgs(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+
+	expectedName := filepath.Base(cwd)
+
+	t.Run("launches session with cwd", func(t *testing.T) {
+		mock := &mockSessionLauncher{}
+		controller := NewHereController(mock)
+
+		err := controller.HandleArgs([]string{})
+		if err != nil {
+			t.Fatalf("HandleArgs() error = %v, want nil", err)
+		}
+
+		if mock.launchedName != expectedName {
+			t.Fatalf("LaunchSession name = %q, want %q", mock.launchedName, expectedName)
+		}
+
+		if mock.launchedDir != cwd {
+			t.Fatalf("LaunchSession dir = %q, want %q", mock.launchedDir, cwd)
+		}
+	})
+
+	t.Run("returns session launcher error", func(t *testing.T) {
+		mock := &mockSessionLauncher{err: fmt.Errorf("session failed")}
+		controller := NewHereController(mock)
+
+		err := controller.HandleArgs([]string{})
+		if err == nil {
+			t.Fatalf("HandleArgs() error = nil, want error")
+		}
+	})
+}

--- a/internal/controllers/new.go
+++ b/internal/controllers/new.go
@@ -18,14 +18,14 @@ type projectCreator interface {
 }
 
 type NewController struct {
-	fzf     selecter
-	creater projectCreator
-	tmux    sessionLauncher
-	config  newConfig
+	fzf      selecter
+	creater  projectCreator
+	sessions sessionLauncher
+	config   newConfig
 }
 
-func NewNewController(fzf selecter, creater projectCreator, tmux sessionLauncher, config newConfig) NewController {
-	return NewController{fzf, creater, tmux, config}
+func NewNewController(fzf selecter, creater projectCreator, sessions sessionLauncher, config newConfig) NewController {
+	return NewController{fzf, creater, sessions, config}
 }
 
 func (c NewController) HandleArgs(args []string) error {
@@ -50,7 +50,7 @@ func (c NewController) HandleArgs(args []string) error {
 	}
 
 	if c.config.OpenNewProjects() {
-		return c.tmux.LaunchSession(projectName, projPath)
+		return c.sessions.LaunchSession(projectName, projPath)
 	}
 
 	return nil

--- a/internal/controllers/open.go
+++ b/internal/controllers/open.go
@@ -29,11 +29,11 @@ type openProjectLister interface {
 type OpenController struct {
 	projects openProjectLister
 	fzf      selecter
-	tmux     sessionLauncher
+	sessions sessionLauncher
 }
 
-func NewOpenController(projects openProjectLister, fzf selecter, tmux sessionLauncher) OpenController {
-	return OpenController{projects, fzf, tmux}
+func NewOpenController(projects openProjectLister, fzf selecter, sessions sessionLauncher) OpenController {
+	return OpenController{projects, fzf, sessions}
 }
 
 func (c OpenController) HandleArgs(args []string) error {
@@ -53,5 +53,5 @@ func (c OpenController) HandleArgs(args []string) error {
 		return fmt.Errorf("unable to get project path: %v", err.Error())
 	}
 
-	return c.tmux.LaunchSession(proj, projPath)
+	return c.sessions.LaunchSession(proj, projPath)
 }

--- a/internal/controllers/remote.go
+++ b/internal/controllers/remote.go
@@ -27,15 +27,15 @@ type remoteConfig interface {
 }
 
 type RemoteController struct {
-	remote remoteProjectManager
-	local  localProjectsIndex
-	fzf    selecter
-	tmux   sessionLauncher
-	config remoteConfig
+	remote   remoteProjectManager
+	local    localProjectsIndex
+	fzf      selecter
+	sessions sessionLauncher
+	config   remoteConfig
 }
 
-func NewRemoteController(remote remoteProjectManager, local localProjectsIndex, fzf selecter, tmux sessionLauncher, config remoteConfig) RemoteController {
-	return RemoteController{remote, local, fzf, tmux, config}
+func NewRemoteController(remote remoteProjectManager, local localProjectsIndex, fzf selecter, sessions sessionLauncher, config remoteConfig) RemoteController {
+	return RemoteController{remote, local, fzf, sessions, config}
 }
 
 func (c RemoteController) HandleArgs(args []string) error {
@@ -71,5 +71,5 @@ func (c RemoteController) HandleArgs(args []string) error {
 		return fmt.Errorf("unable to get clone project: %v", err.Error())
 	}
 
-	return c.tmux.LaunchSession(proj, projPath)
+	return c.sessions.LaunchSession(proj, projPath)
 }

--- a/internal/services/sanitiser.go
+++ b/internal/services/sanitiser.go
@@ -1,0 +1,24 @@
+package services
+
+import "strings"
+
+type Sanitiser struct{}
+
+func NewSanitiser() Sanitiser {
+	return Sanitiser{}
+}
+
+func (s Sanitiser) Sanitise(name string) string {
+	if name == "/" {
+		return "root"
+	}
+
+	name = strings.TrimLeft(name, ".")
+	name = strings.ReplaceAll(name, ":", "-")
+
+	if name == "" {
+		return "session"
+	}
+
+	return name
+}

--- a/internal/services/sanitiser_test.go
+++ b/internal/services/sanitiser_test.go
@@ -1,0 +1,29 @@
+package services
+
+import "testing"
+
+func TestSanitiser_Sanitise(t *testing.T) {
+	sanitiser := NewSanitiser()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"normal name passes through", "myproject", "myproject"},
+		{"colons replaced with hyphens", "my:project", "my-project"},
+		{"root directory becomes root", "/", "root"},
+		{"leading dot stripped", ".hidden", "hidden"},
+		{"empty string becomes session", "", "session"},
+		{"multiple bad chars", ".:bad:name", "-bad-name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitiser.Sanitise(tt.input)
+			if result != tt.expected {
+				t.Fatalf("Sanitise(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func run(args []string) {
 		"remote":   controllers.NewRemoteController(github, projects, selector, sessionProvider, config),
 		"clone":    controllers.NewCloneController(github, selector, sessionProvider, config),
 		"active":   controllers.NewActiveController(projects, selector, sessionProvider),
+		"here":     controllers.NewHereController(sessionProvider),
 		"config":   controllers.NewConfigController(config),
 		"rm":       controllers.NewRmController(projects, selector, git),
 		"help":     controllers.NewHelpController(),

--- a/main.go
+++ b/main.go
@@ -63,6 +63,8 @@ func run(args []string) {
 	git := services.NewGitService()
 	worktree := services.NewWorktreeService()
 
+	sanitiser := services.NewSanitiser()
+
 	sessionProvider, err := services.NewSessionProvider(providerCfg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err.Error())
@@ -80,7 +82,7 @@ func run(args []string) {
 		"remote":   controllers.NewRemoteController(github, projects, selector, sessionProvider, config),
 		"clone":    controllers.NewCloneController(github, selector, sessionProvider, config),
 		"active":   controllers.NewActiveController(projects, selector, sessionProvider),
-		"here":     controllers.NewHereController(sessionProvider),
+		"here":     controllers.NewHereController(sessionProvider, sanitiser),
 		"config":   controllers.NewConfigController(config),
 		"rm":       controllers.NewRmController(projects, selector, git),
 		"help":     controllers.NewHelpController(),


### PR DESCRIPTION
## Summary

- Adds `projman here` command that launches a session in the current working directory, using the directory basename as the session name
- Useful for ad-hoc work in directories outside configured project dirs
- Includes unit tests for the new controller

## Test plan

- [x] `mise run test` passes
- [x] `clint` CI pipeline passes
- [x] Manual: run `projman here` from an arbitrary directory and verify a session is created with the correct name