### PR TITLE
feat: add notes command

### DIFF
--- a/internal/controllers/help.go
+++ b/internal/controllers/help.go
@@ -18,6 +18,7 @@ Commands
   active    Open an existing session
   here      Open a session in the current directory
   list      List all local projects (optionally filter by directory name)
+  notes     Open project notes in your editor
   config    Open the projman config in your editor
   rm        Remove a project from your machine
   worktree  Manage git worktrees -- run 'projman wt help' for details (alias: wt)

--- a/internal/controllers/notes.go
+++ b/internal/controllers/notes.go
@@ -1,0 +1,80 @@
+package controllers
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+type notesProjectResolver interface {
+	ResolveCurrentProject() (string, string, error)
+}
+
+type notesPathProvider interface {
+	NotePath(projPath string) (string, error)
+}
+
+type notesProjectLister interface {
+	ListProjects() ([]string, error)
+	GetPath(project string) (string, error)
+}
+
+type notesSelecter interface {
+	Select(options []string) (string, error)
+}
+
+type NotesController struct {
+	resolver notesProjectResolver
+	notes    notesPathProvider
+	projects notesProjectLister
+	fzf      notesSelecter
+}
+
+func NewNotesController(resolver notesProjectResolver, notes notesPathProvider, projects notesProjectLister, fzf notesSelecter) NotesController {
+	return NotesController{resolver, notes, projects, fzf}
+}
+
+func (c NotesController) HandleArgs(args []string) error {
+	projPath, err := c.resolveProjectPath()
+	if err != nil {
+		return err
+	}
+
+	notePath, err := c.notes.NotePath(projPath)
+	if err != nil {
+		return fmt.Errorf("resolving note path: %v", err.Error())
+	}
+
+	editor := getEditor()
+	cmd := exec.Command(editor, notePath)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+func (c NotesController) resolveProjectPath() (string, error) {
+	_, projPath, err := c.resolver.ResolveCurrentProject()
+	if err == nil {
+		return projPath, nil
+	}
+
+	projects, err := c.projects.ListProjects()
+	if err != nil {
+		return "", fmt.Errorf("unable to fetch local projects: %v", err.Error())
+	}
+
+	proj, err := c.fzf.Select(projects)
+	if err != nil {
+		return "", errors.New("no project selected")
+	}
+
+	projPath, err = c.projects.GetPath(proj)
+	if err != nil {
+		return "", fmt.Errorf("unable to get project path: %v", err.Error())
+	}
+
+	return projPath, nil
+}

--- a/internal/controllers/notes.go
+++ b/internal/controllers/notes.go
@@ -66,9 +66,13 @@ func (c NotesController) resolveProjectPath() (string, error) {
 		return "", fmt.Errorf("unable to fetch local projects: %v", err.Error())
 	}
 
+	if len(projects) == 0 {
+		return "", errors.New("no local projects found")
+	}
+
 	proj, err := c.fzf.Select(projects)
 	if err != nil {
-		return "", errors.New("no project selected")
+		return "", fmt.Errorf("selecting project: %v", err.Error())
 	}
 
 	projPath, err = c.projects.GetPath(proj)

--- a/internal/controllers/notes_test.go
+++ b/internal/controllers/notes_test.go
@@ -1,0 +1,154 @@
+package controllers
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type mockNotesProjectResolver struct {
+	returnName string
+	returnPath string
+	returnErr  error
+}
+
+func (m *mockNotesProjectResolver) ResolveCurrentProject() (string, string, error) {
+	return m.returnName, m.returnPath, m.returnErr
+}
+
+type mockNotesPathProvider struct {
+	returnPath     string
+	returnErr      error
+	calledProjPath string
+}
+
+func (m *mockNotesPathProvider) NotePath(projPath string) (string, error) {
+	m.calledProjPath = projPath
+	return m.returnPath, m.returnErr
+}
+
+type mockNotesProjectLister struct {
+	returnProjects []string
+	returnListErr  error
+	returnPath     string
+	returnGetErr   error
+	calledProject  string
+}
+
+func (m *mockNotesProjectLister) ListProjects() ([]string, error) {
+	return m.returnProjects, m.returnListErr
+}
+
+func (m *mockNotesProjectLister) GetPath(project string) (string, error) {
+	m.calledProject = project
+	return m.returnPath, m.returnGetErr
+}
+
+type mockNotesSelecter struct {
+	returnSelected string
+	returnErr      error
+	calledOptions  []string
+}
+
+func (m *mockNotesSelecter) Select(options []string) (string, error) {
+	m.calledOptions = options
+	return m.returnSelected, m.returnErr
+}
+
+func TestNotesControllerHandleArgs(t *testing.T) {
+	t.Run("insideProjectDir", func(t *testing.T) {
+		t.Setenv("EDITOR", "true")
+
+		resolver := &mockNotesProjectResolver{
+			returnName: "projman",
+			returnPath: "/Users/dan/Personal/projman",
+		}
+		notes := &mockNotesPathProvider{returnPath: "/data/notes/personal_projman.md"}
+		projects := &mockNotesProjectLister{}
+		fzf := &mockNotesSelecter{}
+
+		controller := NewNotesController(resolver, notes, projects, fzf)
+		err := controller.HandleArgs(nil)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if notes.calledProjPath != "/Users/dan/Personal/projman" {
+			t.Fatalf("NotePath called with %q, want %q", notes.calledProjPath, "/Users/dan/Personal/projman")
+		}
+		if fzf.calledOptions != nil {
+			t.Fatalf("Select should not be called when inside a project dir")
+		}
+	})
+
+	t.Run("outsideProjectDir", func(t *testing.T) {
+		t.Setenv("EDITOR", "true")
+
+		resolver := &mockNotesProjectResolver{
+			returnErr: errors.New("not in a project"),
+		}
+		notes := &mockNotesPathProvider{returnPath: "/data/notes/personal_projman.md"}
+		projects := &mockNotesProjectLister{
+			returnProjects: []string{"projman", "myapp"},
+			returnPath:     "/Users/dan/Personal/projman",
+		}
+		fzf := &mockNotesSelecter{returnSelected: "projman"}
+
+		controller := NewNotesController(resolver, notes, projects, fzf)
+		err := controller.HandleArgs(nil)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(fzf.calledOptions) != 2 {
+			t.Fatalf("Select called with %d options, want 2", len(fzf.calledOptions))
+		}
+		if projects.calledProject != "projman" {
+			t.Fatalf("GetPath called with %q, want %q", projects.calledProject, "projman")
+		}
+		if notes.calledProjPath != "/Users/dan/Personal/projman" {
+			t.Fatalf("NotePath called with %q, want %q", notes.calledProjPath, "/Users/dan/Personal/projman")
+		}
+	})
+
+	t.Run("fuzzySelectCancelled", func(t *testing.T) {
+		resolver := &mockNotesProjectResolver{
+			returnErr: errors.New("not in a project"),
+		}
+		notes := &mockNotesPathProvider{}
+		projects := &mockNotesProjectLister{
+			returnProjects: []string{"projman"},
+		}
+		fzf := &mockNotesSelecter{returnErr: errors.New("cancelled")}
+
+		controller := NewNotesController(resolver, notes, projects, fzf)
+		err := controller.HandleArgs(nil)
+
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "no project selected") {
+			t.Fatalf("expected 'no project selected' error, got: %v", err)
+		}
+	})
+
+	t.Run("notePathError", func(t *testing.T) {
+		resolver := &mockNotesProjectResolver{
+			returnName: "projman",
+			returnPath: "/Users/dan/Personal/projman",
+		}
+		notes := &mockNotesPathProvider{returnErr: errors.New("notes dir failed")}
+		projects := &mockNotesProjectLister{}
+		fzf := &mockNotesSelecter{}
+
+		controller := NewNotesController(resolver, notes, projects, fzf)
+		err := controller.HandleArgs(nil)
+
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "notes dir failed") {
+			t.Fatalf("expected error to contain 'notes dir failed', got: %v", err)
+		}
+	})
+}

--- a/internal/controllers/notes_test.go
+++ b/internal/controllers/notes_test.go
@@ -127,8 +127,32 @@ func TestNotesControllerHandleArgs(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), "no project selected") {
-			t.Fatalf("expected 'no project selected' error, got: %v", err)
+		if !strings.Contains(err.Error(), "selecting project") {
+			t.Fatalf("expected 'selecting project' error, got: %v", err)
+		}
+	})
+
+	t.Run("noLocalProjects", func(t *testing.T) {
+		resolver := &mockNotesProjectResolver{
+			returnErr: errors.New("not in a project"),
+		}
+		notes := &mockNotesPathProvider{}
+		projects := &mockNotesProjectLister{
+			returnProjects: []string{},
+		}
+		fzf := &mockNotesSelecter{}
+
+		controller := NewNotesController(resolver, notes, projects, fzf)
+		err := controller.HandleArgs(nil)
+
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "no local projects found") {
+			t.Fatalf("expected 'no local projects found' error, got: %v", err)
+		}
+		if fzf.calledOptions != nil {
+			t.Fatalf("Select should not be called when there are no projects")
 		}
 	})
 

--- a/internal/repositories/notes.go
+++ b/internal/repositories/notes.go
@@ -31,7 +31,7 @@ func (r NotesRepository) NotesDir() (string, error) {
 func userDataDir() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("unable to get users home dir: %v", err.Error())
+		return "", fmt.Errorf("unable to get user's home dir: %v", err.Error())
 	}
 
 	if runtime.GOOS == "darwin" {

--- a/internal/repositories/notes.go
+++ b/internal/repositories/notes.go
@@ -1,0 +1,42 @@
+package repositories
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+type NotesRepository struct{}
+
+func NewNotesRepository() NotesRepository {
+	return NotesRepository{}
+}
+
+func (r NotesRepository) NotesDir() (string, error) {
+	dataDir, err := userDataDir()
+	if err != nil {
+		return "", fmt.Errorf("unable to get data directory: %v", err.Error())
+	}
+
+	notesDir := filepath.Join(dataDir, "notes")
+
+	if err := os.MkdirAll(notesDir, 0755); err != nil {
+		return "", fmt.Errorf("unable to create notes directory: %v", err.Error())
+	}
+
+	return notesDir, nil
+}
+
+func userDataDir() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("unable to get users home dir: %v", err.Error())
+	}
+
+	if runtime.GOOS == "darwin" {
+		return filepath.Join(homeDir, "Library", "Application Support", "projman"), nil
+	}
+
+	return filepath.Join(homeDir, ".local", "share", "projman"), nil
+}

--- a/internal/repositories/notes_test.go
+++ b/internal/repositories/notes_test.go
@@ -1,0 +1,76 @@
+package repositories
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestUserDataDir(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	dataDir, err := userDataDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(dataDir, "projman") {
+		t.Errorf("expected path to contain 'projman', got %s", dataDir)
+	}
+
+	if runtime.GOOS == "darwin" {
+		if !strings.Contains(dataDir, filepath.Join("Library", "Application Support")) {
+			t.Errorf("expected macOS path to contain 'Library/Application Support', got %s", dataDir)
+		}
+	}
+}
+
+func TestNotesDir(t *testing.T) {
+	t.Run("creates the directory on disk", func(t *testing.T) {
+		tempHome := t.TempDir()
+		t.Setenv("HOME", tempHome)
+
+		repo := NewNotesRepository()
+		notesDir, err := repo.NotesDir()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		info, err := os.Stat(notesDir)
+		if err != nil {
+			t.Fatalf("expected notes directory to exist: %v", err)
+		}
+
+		if !info.IsDir() {
+			t.Error("expected notes path to be a directory")
+		}
+
+		if !strings.HasSuffix(notesDir, "notes") {
+			t.Errorf("expected path to end with 'notes', got %s", notesDir)
+		}
+	})
+
+	t.Run("is idempotent", func(t *testing.T) {
+		tempHome := t.TempDir()
+		t.Setenv("HOME", tempHome)
+
+		repo := NewNotesRepository()
+
+		first, err := repo.NotesDir()
+		if err != nil {
+			t.Fatalf("first call: unexpected error: %v", err)
+		}
+
+		second, err := repo.NotesDir()
+		if err != nil {
+			t.Fatalf("second call: unexpected error: %v", err)
+		}
+
+		if first != second {
+			t.Errorf("expected same path, got %s and %s", first, second)
+		}
+	})
+}

--- a/internal/services/notes.go
+++ b/internal/services/notes.go
@@ -1,0 +1,68 @@
+package services
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type notesConfig interface {
+	ProjectDirs() []string
+}
+
+type notesRepository interface {
+	NotesDir() (string, error)
+}
+
+type NotesService struct {
+	config    notesConfig
+	notesRepo notesRepository
+}
+
+func NewNotesService(config notesConfig, notesRepo notesRepository) NotesService {
+	return NotesService{
+		config:    config,
+		notesRepo: notesRepo,
+	}
+}
+
+func (s NotesService) NoteFilename(projPath string) string {
+	parent := strings.ToLower(filepath.Base(filepath.Dir(projPath)))
+	project := filepath.Base(projPath)
+	return fmt.Sprintf("%v_%v.md", parent, project)
+}
+
+func (s NotesService) ResolveCurrentProject() (string, string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", "", fmt.Errorf("getting current directory: %v", err.Error())
+	}
+
+	for _, dir := range s.config.ProjectDirs() {
+		if !strings.HasPrefix(cwd, dir) {
+			continue
+		}
+
+		relative := strings.TrimPrefix(cwd, dir)
+		if relative == "" {
+			continue
+		}
+
+		projectName := strings.SplitN(relative, string(filepath.Separator), 2)[0]
+		projectPath := filepath.Join(dir, projectName)
+		return projectName, projectPath, nil
+	}
+
+	return "", "", errors.New("current directory is not inside a known project")
+}
+
+func (s NotesService) NotePath(projPath string) (string, error) {
+	notesDir, err := s.notesRepo.NotesDir()
+	if err != nil {
+		return "", fmt.Errorf("getting notes directory: %v", err.Error())
+	}
+
+	return filepath.Join(notesDir, s.NoteFilename(projPath)), nil
+}

--- a/internal/services/notes_test.go
+++ b/internal/services/notes_test.go
@@ -1,0 +1,160 @@
+package services
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type mockNotesConfig struct {
+	projectDirs []string
+}
+
+func (m mockNotesConfig) ProjectDirs() []string {
+	return m.projectDirs
+}
+
+type mockNotesRepository struct {
+	notesDir string
+	err      error
+}
+
+func (m mockNotesRepository) NotesDir() (string, error) {
+	return m.notesDir, m.err
+}
+
+func TestNoteFilename(t *testing.T) {
+	service := NewNotesService(mockNotesConfig{}, mockNotesRepository{})
+
+	tests := []struct {
+		name     string
+		projPath string
+		expected string
+	}{
+		{
+			name:     "standard project path",
+			projPath: "/Users/dan/Personal/projman",
+			expected: "personal_projman.md",
+		},
+		{
+			name:     "work project path",
+			projPath: "/Users/dan/Work/myapp",
+			expected: "work_myapp.md",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := service.NoteFilename(tt.projPath)
+			if result != tt.expected {
+				t.Errorf("NoteFilename(%q) = %q, want %q", tt.projPath, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNotePath(t *testing.T) {
+	t.Run("assembles full note path", func(t *testing.T) {
+		service := NewNotesService(mockNotesConfig{}, mockNotesRepository{
+			notesDir: "/home/dan/.local/share/projman/notes",
+		})
+
+		result, err := service.NotePath("/Users/dan/Personal/projman")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expected := "/home/dan/.local/share/projman/notes/personal_projman.md"
+		if result != expected {
+			t.Errorf("NotePath() = %q, want %q", result, expected)
+		}
+	})
+
+	t.Run("returns error when NotesDir fails", func(t *testing.T) {
+		service := NewNotesService(mockNotesConfig{}, mockNotesRepository{
+			err: errors.New("no data dir"),
+		})
+
+		_, err := service.NotePath("/Users/dan/Personal/projman")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestResolveCurrentProject(t *testing.T) {
+	tests := []struct {
+		name         string
+		cwdRelative  string
+		expectedName string
+		expectedPath string
+		expectError  bool
+	}{
+		{
+			name:         "cwd at project root",
+			cwdRelative:  "Personal/projman",
+			expectedName: "projman",
+			expectedPath: "Personal/projman",
+			expectError:  false,
+		},
+		{
+			name:         "cwd in subdirectory",
+			cwdRelative:  "Personal/projman/internal/services",
+			expectedName: "projman",
+			expectedPath: "Personal/projman",
+			expectError:  false,
+		},
+		{
+			name:        "cwd outside all project dirs",
+			cwdRelative: "Other/something",
+			expectError: true,
+		},
+		{
+			name:        "cwd is the project dir itself",
+			cwdRelative: "Personal",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			cwdPath := filepath.Join(tmpDir, tt.cwdRelative)
+			if err := os.MkdirAll(cwdPath, 0755); err != nil {
+				t.Fatalf("failed to create cwd: %v", err)
+			}
+			t.Chdir(cwdPath)
+
+			projectDir := filepath.Join(tmpDir, "Personal") + "/"
+
+			service := NewNotesService(
+				mockNotesConfig{projectDirs: []string{projectDir}},
+				mockNotesRepository{},
+			)
+
+			name, path, err := service.ResolveCurrentProject()
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if name != tt.expectedName {
+				t.Errorf("name = %q, want %q", name, tt.expectedName)
+			}
+
+			expectedFullPath := filepath.Join(tmpDir, tt.expectedPath)
+			if path != expectedFullPath {
+				t.Errorf("path = %q, want %q", path, expectedFullPath)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ func parseProviderFlag(args []string) (string, []string, error) {
 
 func run(args []string) {
 	config := repositories.NewConfigRepository()
+	notesRepo := repositories.NewNotesRepository()
 
 	providerFlag, args, err := parseProviderFlag(args)
 	if err != nil {
@@ -62,6 +63,7 @@ func run(args []string) {
 	health := services.NewHealthService()
 	git := services.NewGitService()
 	worktree := services.NewWorktreeService()
+	notes := services.NewNotesService(config, notesRepo)
 
 	sanitiser := services.NewSanitiser()
 
@@ -85,6 +87,7 @@ func run(args []string) {
 		"here":     controllers.NewHereController(sessionProvider, sanitiser),
 		"config":   controllers.NewConfigController(config),
 		"rm":       controllers.NewRmController(projects, selector, git),
+		"notes":    controllers.NewNotesController(notes, notes, projects, selector),
 		"list":     controllers.NewListController(projects),
 		"help":     controllers.NewHelpController(),
 		"health":   controllers.NewHealthController(health),


### PR DESCRIPTION
## Summary

- Add `projman notes` command to open project notes in the user's editor
- Auto-resolves the current project when inside a project directory, falls back to fuzzy select otherwise
- Notes stored as markdown files in OS-specific data directory (`~/Library/Application Support/projman/notes/` on macOS, `~/.local/share/projman/notes/` on Linux)

## Changes

- **Repository layer**: `NotesRepository` with `NotesDir()` and OS-specific `userDataDir()`
- **Service layer**: `NotesService` with `ResolveCurrentProject()`, `NoteFilename()`, and `NotePath()`
- **Controller layer**: `NotesController` with auto-resolve/fuzzy-select routing and editor launch
- **Wiring**: registered in `main.go` and added to help menu

## Test plan

- [ ] `go test ./...` passes
- [ ] `cd ~/Personal/projman && go run . notes` opens `personal_projman.md` in editor
- [ ] `cd /tmp && go run . notes` shows fuzzy select
- [ ] `go run . help` shows notes in command list