### PR TITLE
feat: skip configured paths in worktree copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,32 @@ projman uses a JSON configuration file located at `~/.config/projman/config.json
 | `session_provider` | string | `"tmux"` | Session provider to use (`tmux` or `vscode`) |
 | `tmux.windows` | array | `["CLI", "Code", "Server"]` | Names of tmux windows to create |
 | `tmux.starting_window` | number | `2` | Which window to start in |
+| `worktree_copy_excludes` | array | `[]` | Glob patterns to skip when copying gitignored files into a new worktree |
+
+### Worktree copy excludes
+
+When `projman worktree new` or `projman worktree checkout` prompts to copy
+ignored files into the new worktree, any path matching one of the
+`worktree_copy_excludes` patterns is skipped. This is useful for very large
+ignored directories (such as `node_modules` or build outputs) that you would
+rather rebuild than copy.
+
+Patterns use [doublestar](https://github.com/bmatcuk/doublestar) glob syntax,
+matched against paths returned by `git ls-files` (relative to the repository
+root):
+
+```json
+{
+  "worktree_copy_excludes": ["**/node_modules", "dist", "*.log"]
+}
+```
+
+- `node_modules` matches only the top-level `node_modules` directory
+- `**/node_modules` matches `node_modules` at any depth
+- `*.log` matches top-level log files
+- `**/*.log` matches log files at any depth
+
+Invalid patterns cause projman to exit at startup with an error.
 
 ## Session Providers
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/danielronalds/projman
 
 go 1.24.2
 
-require github.com/koki-develop/go-fzf v0.15.0
+require (
+	github.com/bmatcuk/doublestar/v4 v4.10.0
+	github.com/koki-develop/go-fzf v0.15.0
+)
 
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=
 github.com/charmbracelet/bubbles v1.0.0/go.mod h1:9d/Zd5GdnauMI5ivUIVisuEm3ave1XwXtD1ckyV6r3E=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=

--- a/internal/repositories/config.go
+++ b/internal/repositories/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/danielronalds/projman/internal/services"
 )
 
@@ -32,15 +33,16 @@ func (t template) GetCommands() []string {
 }
 
 type config struct {
-	Theme           string        `json:"theme"`
-	Layout          string        `json:"layout"`
-	ProjectDirs     []string      `json:"projectDirs"`
-	OpenNewProjects bool          `json:"openNewProjects"`
-	Templates       []template    `json:"templates"`
-	SessionProvider string        `json:"session_provider"`
-	Tmux            tmuxConfig    `json:"tmux"`
-	VSCode          vsCodeConfig  `json:"vscode"`
-	SessionLayout   sessionLayout `json:"session_layout,omitempty"`
+	Theme                string        `json:"theme"`
+	Layout               string        `json:"layout"`
+	ProjectDirs          []string      `json:"projectDirs"`
+	OpenNewProjects      bool          `json:"openNewProjects"`
+	Templates            []template    `json:"templates"`
+	SessionProvider      string        `json:"session_provider"`
+	Tmux                 tmuxConfig    `json:"tmux"`
+	VSCode               vsCodeConfig  `json:"vscode"`
+	SessionLayout        sessionLayout `json:"session_layout"`
+	WorktreeCopyExcludes []string      `json:"worktree_copy_excludes"`
 }
 
 type ConfigRepository struct {
@@ -59,7 +61,8 @@ func NewConfigRepository() ConfigRepository {
 			Windows:        []string{"CLI", "Code", "Server"},
 			StartingWindow: 2,
 		},
-		VSCode: vsCodeConfig{},
+		VSCode:               vsCodeConfig{},
+		WorktreeCopyExcludes: []string{},
 	}
 
 	homeDir := getHomeDir()
@@ -79,6 +82,13 @@ func NewConfigRepository() ConfigRepository {
 		fmt.Fprintf(os.Stderr, "Error: 'session_layout' is deprecated and no longer supported.\n")
 		fmt.Fprintf(os.Stderr, "Please move your config to the 'tmux' block. See README.md for details.\n")
 		os.Exit(1)
+	}
+
+	for _, p := range conf.WorktreeCopyExcludes {
+		if !doublestar.ValidatePattern(p) {
+			fmt.Fprintf(os.Stderr, "Invalid worktree_copy_excludes pattern: %q\n", p)
+			os.Exit(1)
+		}
 	}
 
 	if conf.SessionProvider == "" {
@@ -150,6 +160,10 @@ func (r ConfigRepository) SessionWindows() []string {
 
 func (r ConfigRepository) StartingWindow() int {
 	return r.conf.Tmux.StartingWindow
+}
+
+func (r ConfigRepository) WorktreeCopyExcludes() []string {
+	return r.conf.WorktreeCopyExcludes
 }
 
 func (r ConfigRepository) ConfigFilePath() string {

--- a/internal/services/worktree.go
+++ b/internal/services/worktree.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 
@@ -182,21 +183,15 @@ func (s WorktreeService) CopyIgnoredFiles(mainPath, worktreePath string) []strin
 	}
 
 	excludes := s.config.WorktreeCopyExcludes()
-	filtered := paths[:0]
-	for _, p := range paths {
+	paths = slices.DeleteFunc(paths, func(p string) bool {
 		matchPath := strings.TrimSuffix(p, "/")
-		skip := false
 		for _, pattern := range excludes {
 			if matched, _ := doublestar.Match(pattern, matchPath); matched {
-				skip = true
-				break
+				return true
 			}
 		}
-		if !skip {
-			filtered = append(filtered, p)
-		}
-	}
-	paths = filtered
+		return false
+	})
 
 	var warnings []string
 	var mu sync.Mutex

--- a/internal/services/worktree.go
+++ b/internal/services/worktree.go
@@ -182,16 +182,17 @@ func (s WorktreeService) CopyIgnoredFiles(mainPath, worktreePath string) []strin
 		return []string{fmt.Sprintf("listing ignored files: %v", err)}
 	}
 
-	excludes := s.config.WorktreeCopyExcludes()
-	paths = slices.DeleteFunc(paths, func(p string) bool {
-		matchPath := strings.TrimSuffix(p, "/")
-		for _, pattern := range excludes {
-			if matched, _ := doublestar.Match(pattern, matchPath); matched {
-				return true
+	if excludes := s.config.WorktreeCopyExcludes(); len(excludes) > 0 {
+		paths = slices.DeleteFunc(paths, func(p string) bool {
+			matchPath := strings.TrimSuffix(p, "/")
+			for _, pattern := range excludes {
+				if matched, _ := doublestar.Match(pattern, matchPath); matched {
+					return true
+				}
 			}
-		}
-		return false
-	})
+			return false
+		})
+	}
 
 	var warnings []string
 	var mu sync.Mutex

--- a/internal/services/worktree.go
+++ b/internal/services/worktree.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/bmatcuk/doublestar/v4"
 )
 
 type worktreeConfig interface {
@@ -178,6 +180,23 @@ func (s WorktreeService) CopyIgnoredFiles(mainPath, worktreePath string) []strin
 	if err != nil {
 		return []string{fmt.Sprintf("listing ignored files: %v", err)}
 	}
+
+	excludes := s.config.WorktreeCopyExcludes()
+	filtered := paths[:0]
+	for _, p := range paths {
+		matchPath := strings.TrimSuffix(p, "/")
+		skip := false
+		for _, pattern := range excludes {
+			if matched, _ := doublestar.Match(pattern, matchPath); matched {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			filtered = append(filtered, p)
+		}
+	}
+	paths = filtered
 
 	var warnings []string
 	var mu sync.Mutex

--- a/internal/services/worktree.go
+++ b/internal/services/worktree.go
@@ -10,10 +10,16 @@ import (
 	"sync"
 )
 
-type WorktreeService struct{}
+type worktreeConfig interface {
+	WorktreeCopyExcludes() []string
+}
 
-func NewWorktreeService() WorktreeService {
-	return WorktreeService{}
+type WorktreeService struct {
+	config worktreeConfig
+}
+
+func NewWorktreeService(config worktreeConfig) WorktreeService {
+	return WorktreeService{config: config}
 }
 
 func (s WorktreeService) IsGitRepo(dir string) bool {

--- a/internal/services/worktree_test.go
+++ b/internal/services/worktree_test.go
@@ -609,18 +609,22 @@ func TestCopyIgnoredFilesExcludes(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		excludes    []string
-		gitignore   string
-		seedFiles   map[string]string
-		seedDirs    []string
-		wantCopied  []string
-		wantSkipped []string
+		name         string
+		excludes     []string
+		gitignore    string
+		trackedFiles map[string]string
+		seedFiles    map[string]string
+		seedDirs     []string
+		wantCopied   []string
+		wantSkipped  []string
 	}{
 		{
 			name:      "topLevelPatternExcludesOnlyTopLevel",
 			excludes:  []string{"node_modules"},
 			gitignore: "node_modules/\n",
+			trackedFiles: map[string]string{
+				"frontend/app.js": "tracked",
+			},
 			seedFiles: map[string]string{
 				"node_modules/pkg/index.js":          "top",
 				"frontend/node_modules/pkg/index.js": "nested",
@@ -633,6 +637,9 @@ func TestCopyIgnoredFilesExcludes(t *testing.T) {
 			name:      "doublestarExcludesAtAnyDepth",
 			excludes:  []string{"**/node_modules"},
 			gitignore: "node_modules/\n",
+			trackedFiles: map[string]string{
+				"frontend/app.js": "tracked",
+			},
 			seedFiles: map[string]string{
 				"node_modules/pkg/index.js":          "top",
 				"frontend/node_modules/pkg/index.js": "nested",
@@ -647,6 +654,9 @@ func TestCopyIgnoredFilesExcludes(t *testing.T) {
 			name:      "globExtensionMatchesTopLevelOnly",
 			excludes:  []string{"*.log"},
 			gitignore: "*.log\n",
+			trackedFiles: map[string]string{
+				"nested/keep.txt": "tracked",
+			},
 			seedFiles: map[string]string{
 				"foo.log":        "top",
 				"nested/bar.log": "nested",
@@ -683,8 +693,17 @@ func TestCopyIgnoredFilesExcludes(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte(tc.gitignore), 0644); err != nil {
 				t.Fatalf("write .gitignore: %v", err)
 			}
-			run(t, repoDir, "git", "add", ".gitignore")
-			run(t, repoDir, "git", "commit", "-m", "add gitignore")
+			for path, content := range tc.trackedFiles {
+				full := filepath.Join(repoDir, path)
+				if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+					t.Fatalf("mkdir for tracked %s: %v", path, err)
+				}
+				if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+					t.Fatalf("write tracked %s: %v", path, err)
+				}
+			}
+			run(t, repoDir, "git", "add", ".")
+			run(t, repoDir, "git", "commit", "-m", "add gitignore + tracked content")
 
 			for _, d := range tc.seedDirs {
 				if err := os.MkdirAll(filepath.Join(repoDir, d), 0755); err != nil {

--- a/internal/services/worktree_test.go
+++ b/internal/services/worktree_test.go
@@ -8,6 +8,14 @@ import (
 	"testing"
 )
 
+type fakeWorktreeConfig struct {
+	excludes []string
+}
+
+func (f fakeWorktreeConfig) WorktreeCopyExcludes() []string {
+	return f.excludes
+}
+
 func TestSanitiseForDirectory(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -39,7 +47,7 @@ func TestIsGitRepo(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	s := NewWorktreeService()
+	s := NewWorktreeService(fakeWorktreeConfig{})
 
 	t.Run("insideGitRepo", func(t *testing.T) {
 		cwd, _ := os.Getwd()
@@ -60,7 +68,7 @@ func TestMainWorktreePath(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	s := NewWorktreeService()
+	s := NewWorktreeService(fakeWorktreeConfig{})
 
 	cwd, _ := os.Getwd()
 	got, err := s.MainWorktreePath(cwd)
@@ -99,7 +107,7 @@ func TestCreateWorktree(t *testing.T) {
 	run(repoDir, "git", "config", "user.name", "Test")
 	run(repoDir, "git", "commit", "--allow-empty", "-m", "initial")
 
-	s := NewWorktreeService()
+	s := NewWorktreeService(fakeWorktreeConfig{})
 
 	t.Run("simpleWorktree", func(t *testing.T) {
 		path, err := s.CreateWorktree(repoDir, "test-branch")
@@ -177,7 +185,7 @@ func TestListWorktrees(t *testing.T) {
 	run(repoDir, "git", "config", "user.name", "Test")
 	run(repoDir, "git", "commit", "--allow-empty", "-m", "initial")
 
-	s := NewWorktreeService()
+	s := NewWorktreeService(fakeWorktreeConfig{})
 
 	t.Run("onlyBase", func(t *testing.T) {
 		names, err := s.ListWorktrees(repoDir)
@@ -253,7 +261,7 @@ func TestWorktreePath(t *testing.T) {
 	run(repoDir, "git", "config", "user.name", "Test")
 	run(repoDir, "git", "commit", "--allow-empty", "-m", "initial")
 
-	s := NewWorktreeService()
+	s := NewWorktreeService(fakeWorktreeConfig{})
 	if _, err := s.CreateWorktree(repoDir, "feature-one"); err != nil {
 		t.Fatalf("CreateWorktree() error = %v", err)
 	}
@@ -322,7 +330,7 @@ func TestListRemoteBranches(t *testing.T) {
 	}
 
 	repoDir, _ := setupRemoteAndClone(t)
-	s := NewWorktreeService()
+	s := NewWorktreeService(fakeWorktreeConfig{})
 
 	t.Run("includesRemoteBranches", func(t *testing.T) {
 		branches, err := s.ListRemoteBranches(repoDir)
@@ -359,7 +367,7 @@ func TestCheckoutWorktree(t *testing.T) {
 	}
 
 	repoDir, tmpDir := setupRemoteAndClone(t)
-	s := NewWorktreeService()
+	s := NewWorktreeService(fakeWorktreeConfig{})
 
 	t.Run("checkoutRemoteBranch", func(t *testing.T) {
 		path, err := s.CheckoutWorktree(repoDir, "origin/feature/test-branch")
@@ -425,7 +433,7 @@ func TestRemoveWorktree(t *testing.T) {
 	run(repoDir, "git", "config", "user.name", "Test")
 	run(repoDir, "git", "commit", "--allow-empty", "-m", "initial")
 
-	s := NewWorktreeService()
+	s := NewWorktreeService(fakeWorktreeConfig{})
 
 	t.Run("removeWorktree", func(t *testing.T) {
 		worktreePath, err := s.CreateWorktree(repoDir, "feature-to-remove")
@@ -459,7 +467,7 @@ func TestCopyIgnoredFiles(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	s := NewWorktreeService()
+	s := NewWorktreeService(fakeWorktreeConfig{})
 
 	type testHelpers struct {
 		run   func(dir string, args ...string)
@@ -593,4 +601,123 @@ func TestCopyIgnoredFiles(t *testing.T) {
 			t.Fatalf("cache.tmp content = %q, want %q", string(content), "cached")
 		}
 	})
+}
+
+func TestCopyIgnoredFilesExcludes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tests := []struct {
+		name        string
+		excludes    []string
+		gitignore   string
+		seedFiles   map[string]string
+		seedDirs    []string
+		wantCopied  []string
+		wantSkipped []string
+	}{
+		{
+			name:      "topLevelPatternExcludesOnlyTopLevel",
+			excludes:  []string{"node_modules"},
+			gitignore: "node_modules/\n",
+			seedFiles: map[string]string{
+				"node_modules/pkg/index.js":          "top",
+				"frontend/node_modules/pkg/index.js": "nested",
+			},
+			seedDirs:    []string{"node_modules/pkg", "frontend/node_modules/pkg"},
+			wantSkipped: []string{"node_modules/pkg/index.js"},
+			wantCopied:  []string{"frontend/node_modules/pkg/index.js"},
+		},
+		{
+			name:      "doublestarExcludesAtAnyDepth",
+			excludes:  []string{"**/node_modules"},
+			gitignore: "node_modules/\n",
+			seedFiles: map[string]string{
+				"node_modules/pkg/index.js":          "top",
+				"frontend/node_modules/pkg/index.js": "nested",
+			},
+			seedDirs: []string{"node_modules/pkg", "frontend/node_modules/pkg"},
+			wantSkipped: []string{
+				"node_modules/pkg/index.js",
+				"frontend/node_modules/pkg/index.js",
+			},
+		},
+		{
+			name:      "globExtensionMatchesTopLevelOnly",
+			excludes:  []string{"*.log"},
+			gitignore: "*.log\n",
+			seedFiles: map[string]string{
+				"foo.log":        "top",
+				"nested/bar.log": "nested",
+			},
+			seedDirs:    []string{"nested"},
+			wantSkipped: []string{"foo.log"},
+			wantCopied:  []string{"nested/bar.log"},
+		},
+	}
+
+	run := func(t *testing.T, dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, output)
+		}
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir, _ := filepath.EvalSymlinks(t.TempDir())
+			repoDir := filepath.Join(tmpDir, "myproject")
+			if err := os.MkdirAll(repoDir, 0755); err != nil {
+				t.Fatalf("failed to create repo dir: %v", err)
+			}
+
+			run(t, repoDir, "git", "init")
+			run(t, repoDir, "git", "config", "user.email", "test@test.com")
+			run(t, repoDir, "git", "config", "user.name", "Test")
+			run(t, repoDir, "git", "commit", "--allow-empty", "-m", "initial")
+
+			if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte(tc.gitignore), 0644); err != nil {
+				t.Fatalf("write .gitignore: %v", err)
+			}
+			run(t, repoDir, "git", "add", ".gitignore")
+			run(t, repoDir, "git", "commit", "-m", "add gitignore")
+
+			for _, d := range tc.seedDirs {
+				if err := os.MkdirAll(filepath.Join(repoDir, d), 0755); err != nil {
+					t.Fatalf("mkdir %s: %v", d, err)
+				}
+			}
+			for path, content := range tc.seedFiles {
+				if err := os.WriteFile(filepath.Join(repoDir, path), []byte(content), 0644); err != nil {
+					t.Fatalf("write %s: %v", path, err)
+				}
+			}
+
+			worktreePath := filepath.Join(tmpDir, "myproject-test")
+			if err := os.MkdirAll(worktreePath, 0755); err != nil {
+				t.Fatalf("mkdir worktree: %v", err)
+			}
+
+			s := NewWorktreeService(fakeWorktreeConfig{excludes: tc.excludes})
+			warnings := s.CopyIgnoredFiles(repoDir, worktreePath)
+			if len(warnings) != 0 {
+				t.Fatalf("expected no warnings, got %v", warnings)
+			}
+
+			for _, path := range tc.wantCopied {
+				if _, err := os.Stat(filepath.Join(worktreePath, path)); err != nil {
+					t.Errorf("expected %s to be copied, got error: %v", path, err)
+				}
+			}
+			for _, path := range tc.wantSkipped {
+				if _, err := os.Stat(filepath.Join(worktreePath, path)); !os.IsNotExist(err) {
+					t.Errorf("expected %s to be skipped, but it exists (err=%v)", path, err)
+				}
+			}
+		})
+	}
 }

--- a/internal/services/worktree_test.go
+++ b/internal/services/worktree_test.go
@@ -16,6 +16,51 @@ func (f fakeWorktreeConfig) WorktreeCopyExcludes() []string {
 	return f.excludes
 }
 
+type repoTestHelpers struct {
+	run   func(dir string, args ...string)
+	mkdir func(path string)
+	write func(path, content string)
+}
+
+func setupGitRepo(t *testing.T) (repoDir string, tmpDir string, h repoTestHelpers) {
+	t.Helper()
+	tmpDir, _ = filepath.EvalSymlinks(t.TempDir())
+	repoDir = filepath.Join(tmpDir, "myproject")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatalf("failed to create repo dir: %v", err)
+	}
+
+	h.run = func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, output)
+		}
+	}
+
+	h.mkdir = func(path string) {
+		t.Helper()
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatalf("failed to create directory %s: %v", path, err)
+		}
+	}
+
+	h.write = func(path, content string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write file %s: %v", path, err)
+		}
+	}
+
+	h.run(repoDir, "git", "init")
+	h.run(repoDir, "git", "config", "user.email", "test@test.com")
+	h.run(repoDir, "git", "config", "user.name", "Test")
+	h.run(repoDir, "git", "commit", "--allow-empty", "-m", "initial")
+	return repoDir, tmpDir, h
+}
+
 func TestSanitiseForDirectory(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -469,53 +514,8 @@ func TestCopyIgnoredFiles(t *testing.T) {
 
 	s := NewWorktreeService(fakeWorktreeConfig{})
 
-	type testHelpers struct {
-		run   func(dir string, args ...string)
-		mkdir func(path string)
-		write func(path, content string)
-	}
-
-	setupRepo := func(t *testing.T) (repoDir string, tmpDir string, h testHelpers) {
-		t.Helper()
-		tmpDir, _ = filepath.EvalSymlinks(t.TempDir())
-		repoDir = filepath.Join(tmpDir, "myproject")
-		if err := os.MkdirAll(repoDir, 0755); err != nil {
-			t.Fatalf("failed to create repo dir: %v", err)
-		}
-
-		h.run = func(dir string, args ...string) {
-			t.Helper()
-			cmd := exec.Command(args[0], args[1:]...)
-			cmd.Dir = dir
-			output, err := cmd.CombinedOutput()
-			if err != nil {
-				t.Fatalf("command %v failed: %v\n%s", args, err, output)
-			}
-		}
-
-		h.mkdir = func(path string) {
-			t.Helper()
-			if err := os.MkdirAll(path, 0755); err != nil {
-				t.Fatalf("failed to create directory %s: %v", path, err)
-			}
-		}
-
-		h.write = func(path, content string) {
-			t.Helper()
-			if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-				t.Fatalf("failed to write file %s: %v", path, err)
-			}
-		}
-
-		h.run(repoDir, "git", "init")
-		h.run(repoDir, "git", "config", "user.email", "test@test.com")
-		h.run(repoDir, "git", "config", "user.name", "Test")
-		h.run(repoDir, "git", "commit", "--allow-empty", "-m", "initial")
-		return repoDir, tmpDir, h
-	}
-
 	t.Run("noGitignore", func(t *testing.T) {
-		repoDir, tmpDir, h := setupRepo(t)
+		repoDir, tmpDir, h := setupGitRepo(t)
 		worktreePath := filepath.Join(tmpDir, "myproject-test")
 
 		h.mkdir(worktreePath)
@@ -526,7 +526,7 @@ func TestCopyIgnoredFiles(t *testing.T) {
 	})
 
 	t.Run("ignoredFileCopied", func(t *testing.T) {
-		repoDir, tmpDir, h := setupRepo(t)
+		repoDir, tmpDir, h := setupGitRepo(t)
 
 		h.write(filepath.Join(repoDir, ".gitignore"), "*.log\n")
 		h.write(filepath.Join(repoDir, "debug.log"), "log content")
@@ -551,7 +551,7 @@ func TestCopyIgnoredFiles(t *testing.T) {
 	})
 
 	t.Run("ignoredDirectoryCopied", func(t *testing.T) {
-		repoDir, tmpDir, h := setupRepo(t)
+		repoDir, tmpDir, h := setupGitRepo(t)
 
 		h.write(filepath.Join(repoDir, ".gitignore"), "node_modules/\n")
 		h.mkdir(filepath.Join(repoDir, "node_modules", "pkg"))
@@ -577,7 +577,7 @@ func TestCopyIgnoredFiles(t *testing.T) {
 	})
 
 	t.Run("nestedGitignore", func(t *testing.T) {
-		repoDir, tmpDir, h := setupRepo(t)
+		repoDir, tmpDir, h := setupGitRepo(t)
 
 		h.mkdir(filepath.Join(repoDir, "subdir"))
 		h.write(filepath.Join(repoDir, "subdir", ".gitignore"), "*.tmp\n")
@@ -667,59 +667,28 @@ func TestCopyIgnoredFilesExcludes(t *testing.T) {
 		},
 	}
 
-	run := func(t *testing.T, dir string, args ...string) {
-		t.Helper()
-		cmd := exec.Command(args[0], args[1:]...)
-		cmd.Dir = dir
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("command %v failed: %v\n%s", args, err, output)
-		}
-	}
-
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, _ := filepath.EvalSymlinks(t.TempDir())
-			repoDir := filepath.Join(tmpDir, "myproject")
-			if err := os.MkdirAll(repoDir, 0755); err != nil {
-				t.Fatalf("failed to create repo dir: %v", err)
-			}
+			repoDir, tmpDir, h := setupGitRepo(t)
 
-			run(t, repoDir, "git", "init")
-			run(t, repoDir, "git", "config", "user.email", "test@test.com")
-			run(t, repoDir, "git", "config", "user.name", "Test")
-			run(t, repoDir, "git", "commit", "--allow-empty", "-m", "initial")
-
-			if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte(tc.gitignore), 0644); err != nil {
-				t.Fatalf("write .gitignore: %v", err)
-			}
+			h.write(filepath.Join(repoDir, ".gitignore"), tc.gitignore)
 			for path, content := range tc.trackedFiles {
 				full := filepath.Join(repoDir, path)
-				if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
-					t.Fatalf("mkdir for tracked %s: %v", path, err)
-				}
-				if err := os.WriteFile(full, []byte(content), 0644); err != nil {
-					t.Fatalf("write tracked %s: %v", path, err)
-				}
+				h.mkdir(filepath.Dir(full))
+				h.write(full, content)
 			}
-			run(t, repoDir, "git", "add", ".")
-			run(t, repoDir, "git", "commit", "-m", "add gitignore + tracked content")
+			h.run(repoDir, "git", "add", ".")
+			h.run(repoDir, "git", "commit", "-m", "add gitignore + tracked content")
 
 			for _, d := range tc.seedDirs {
-				if err := os.MkdirAll(filepath.Join(repoDir, d), 0755); err != nil {
-					t.Fatalf("mkdir %s: %v", d, err)
-				}
+				h.mkdir(filepath.Join(repoDir, d))
 			}
 			for path, content := range tc.seedFiles {
-				if err := os.WriteFile(filepath.Join(repoDir, path), []byte(content), 0644); err != nil {
-					t.Fatalf("write %s: %v", path, err)
-				}
+				h.write(filepath.Join(repoDir, path), content)
 			}
 
 			worktreePath := filepath.Join(tmpDir, "myproject-test")
-			if err := os.MkdirAll(worktreePath, 0755); err != nil {
-				t.Fatalf("mkdir worktree: %v", err)
-			}
+			h.mkdir(worktreePath)
 
 			s := NewWorktreeService(fakeWorktreeConfig{excludes: tc.excludes})
 			warnings := s.CopyIgnoredFiles(repoDir, worktreePath)
@@ -729,12 +698,12 @@ func TestCopyIgnoredFilesExcludes(t *testing.T) {
 
 			for _, path := range tc.wantCopied {
 				if _, err := os.Stat(filepath.Join(worktreePath, path)); err != nil {
-					t.Errorf("expected %s to be copied, got error: %v", path, err)
+					t.Fatalf("expected %s to be copied, got error: %v", path, err)
 				}
 			}
 			for _, path := range tc.wantSkipped {
 				if _, err := os.Stat(filepath.Join(worktreePath, path)); !os.IsNotExist(err) {
-					t.Errorf("expected %s to be skipped, but it exists (err=%v)", path, err)
+					t.Fatalf("expected %s to be skipped, but it exists (err=%v)", path, err)
 				}
 			}
 		})

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func run(args []string) {
 	creater := services.NewCreaterService(config)
 	health := services.NewHealthService()
 	git := services.NewGitService()
-	worktree := services.NewWorktreeService()
+	worktree := services.NewWorktreeService(config)
 	notes := services.NewNotesService(config, notesRepo)
 
 	sanitiser := services.NewSanitiser()

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "latest"
+go = "1.26.3"
 golangci-lint = "latest"
 gotestsum = "latest"
 


### PR DESCRIPTION
## Summary

- Adds a `worktree_copy_excludes` config option: a list of glob patterns that are skipped when copying gitignored files into a new worktree
- Patterns use [doublestar](https://github.com/bmatcuk/doublestar) syntax (`**` supported), matched against `git ls-files` output
- Invalid patterns fail loud at startup via `doublestar.ValidatePattern`
- Default is an empty list -- no behaviour change for existing users

## Changes

- **Config**: `WorktreeCopyExcludes` field, default, validation, and accessor on `ConfigRepository`
- **Service**: `WorktreeService` now takes a `worktreeConfig` dependency; `CopyIgnoredFiles` filters paths via `slices.DeleteFunc` + `doublestar.Match` before fanning out copies
- **Wiring**: `main.go` passes the config into `NewWorktreeService`
- **Tests**: new table-driven `TestCopyIgnoredFilesExcludes` covering top-level, doublestar-any-depth, and extension globs
- **Docs**: README config section + dedicated subsection on glob semantics

## Test plan

- [x] `mise run test` passes
- [x] `clint` CI pipeline passes
- [x] Manual: in a repo with a real `node_modules/`, set `"worktree_copy_excludes": ["**/node_modules"]` and verify `projman worktree new <branch>` copies `.env` etc. but no `node_modules` directories at any depth
- [x] Manual: set an invalid pattern and confirm projman exits with a validation error before doing any work